### PR TITLE
Fixtures: added comment + participation request

### DIFF
--- a/saskatoon/fixtures/dumpdata
+++ b/saskatoon/fixtures/dumpdata
@@ -19,7 +19,7 @@ if [ -z "$1" ]; then
         echo "Aborting"
         exit 1
     fi
-    ../manage.py dumpdata  --indent 2 > "saskatoon.json"
+    ../manage.py dumpdata > "saskatoon.json"
 else
     if [ $1 == "all" ]; then
         # replace all .json files in fixtures/ except saskatoon files
@@ -33,6 +33,3 @@ else
         ../manage.py dumpdata $1  --indent 2 > "${1//./-}.json"
     fi
 fi
-
-
-

--- a/saskatoon/fixtures/harvest-comment.json
+++ b/saskatoon/fixtures/harvest-comment.json
@@ -1,0 +1,12 @@
+[
+{
+  "model": "harvest.comment",
+  "pk": 1,
+  "fields": {
+    "content": "Everything went smoothly. Owner was very helpful.",
+    "created_date": "2021-05-31T13:35:30.088Z",
+    "author": 2,
+    "harvest": 1
+  }
+}
+]

--- a/saskatoon/fixtures/harvest-harvest.json
+++ b/saskatoon/fixtures/harvest-harvest.json
@@ -11,7 +11,7 @@
     "pick_leader": 2,
     "start_date": "2021-06-06T10:00:00Z",
     "end_date": "2021-06-06T10:00:00Z",
-    "publication_date": "2021-05-27T18:43:51.899Z",
+    "publication_date": "2021-05-31T13:58:24.180Z",
     "creation_date": "2021-05-26T21:42:50.701Z",
     "nb_required_pickers": 3,
     "about": "<p>Un tas de belles pommes et de noix de Grenoble au coin Mont-Royal et Buillon</p>",

--- a/saskatoon/fixtures/harvest-requestforparticipation.json
+++ b/saskatoon/fixtures/harvest-requestforparticipation.json
@@ -1,0 +1,18 @@
+[
+{
+  "model": "harvest.requestforparticipation",
+  "pk": 1,
+  "fields": {
+    "picker": 4,
+    "number_of_people": 1,
+    "comment": "I live in the neighborhood and could bring a small step ladder.",
+    "notes_from_pickleader": "",
+    "harvest": 1,
+    "creation_date": "2021-05-31T13:38:14.221Z",
+    "acceptation_date": null,
+    "is_accepted": null,
+    "showed_up": null,
+    "is_cancelled": false
+  }
+}
+]

--- a/saskatoon/fixtures/init
+++ b/saskatoon/fixtures/init
@@ -25,6 +25,8 @@ seq=(member-city \
      harvest-equipment \
      harvest-harvest \
      harvest-harvestyield \
+     harvest-comment \
+     harvest-requestforparticipation \
     )
 
 ignore="-e ^saskatoon"
@@ -46,5 +48,3 @@ echo "Unused .json fixtures:"; echo $unused
 #     echo "Loading $fix"
 #     ./loaddata $fix
 # done
-
-

--- a/saskatoon/fixtures/member-actor.json
+++ b/saskatoon/fixtures/member-actor.json
@@ -13,5 +13,10 @@
   "model": "member.actor",
   "pk": 3,
   "fields": {}
+},
+{
+  "model": "member.actor",
+  "pk": 4,
+  "fields": {}
 }
 ]

--- a/saskatoon/fixtures/member-authuser.json
+++ b/saskatoon/fixtures/member-authuser.json
@@ -10,7 +10,7 @@
     "email": "pick@leader.com",
     "date_joined": "2021-05-26T21:26:41.699Z",
     "is_active": true,
-    "is_staff": false,
+    "is_staff": true,
     "groups": [],
     "user_permissions": []
   }

--- a/saskatoon/fixtures/member-authuser.json
+++ b/saskatoon/fixtures/member-authuser.json
@@ -4,11 +4,27 @@
   "pk": 2,
   "fields": {
     "password": "pbkdf2_sha256$260000$B4izrSL5cMDhpz76Ml8oAd$y+vALyJB3hKoOGYietAefzmZQMA0TSPrbGq4WLI7yvs=",
-    "last_login": null,
+    "last_login": "2021-05-31T13:34:39.971Z",
     "is_superuser": false,
     "person": 3,
     "email": "pick@leader.com",
     "date_joined": "2021-05-26T21:26:41.699Z",
+    "is_active": true,
+    "is_staff": false,
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "member.authuser",
+  "pk": 3,
+  "fields": {
+    "password": "",
+    "last_login": null,
+    "is_superuser": false,
+    "person": 4,
+    "email": "volunteer@picker.com",
+    "date_joined": "2021-05-31T13:38:14.213Z",
     "is_active": true,
     "is_staff": false,
     "groups": [],

--- a/saskatoon/fixtures/member-language.json
+++ b/saskatoon/fixtures/member-language.json
@@ -14,10 +14,10 @@
   }
 },
 {
-    "model": "member.language",
-    "pk": 3,
-    "fields": {
-        "name": "Español"
-    }
+  "model": "member.language",
+  "pk": 3,
+  "fields": {
+    "name": "Español"
+  }
 }
 ]

--- a/saskatoon/fixtures/member-person.json
+++ b/saskatoon/fixtures/member-person.json
@@ -44,5 +44,28 @@
     "language": null,
     "comments": ""
   }
+},
+{
+  "model": "member.person",
+  "pk": 4,
+  "fields": {
+    "redmine_contact_id": null,
+    "first_name": "Volunteer",
+    "family_name": "Picker",
+    "phone": "438-666-1234",
+    "street_number": null,
+    "street": null,
+    "complement": null,
+    "postal_code": null,
+    "neighborhood": null,
+    "city": 1,
+    "state": 1,
+    "country": 1,
+    "newsletter_subscription": false,
+    "longitude": null,
+    "latitude": null,
+    "language": null,
+    "comments": ""
+  }
 }
 ]


### PR DESCRIPTION
Added 1 comment + 1 participation_request fixtures. I had issues with the send_email function: ConnectionRefusedError: [Errno 111] Connection refused). So in order for `saskatoon/fixtures/init` to pass I needed to set fail_silently=True in `send_email()` from `harvest/signals.py.`