### PR TITLE
install Rosetta to manage transations

### DIFF
--- a/saskatoon/saskatoon/settings.py
+++ b/saskatoon/saskatoon/settings.py
@@ -74,6 +74,7 @@ INSTALLED_APPS = [
     'crispy_forms',
     'debug_toolbar',
     'django_extensions',
+    'rosetta'
 ]
 
 MIDDLEWARE = [

--- a/saskatoon/saskatoon/urls.py
+++ b/saskatoon/saskatoon/urls.py
@@ -12,4 +12,6 @@ urlpatterns = [
     path('accounts/', include('django.contrib.auth.urls')),
     path('i18n/', include('django.conf.urls.i18n')),
     path('__debug__/', include(debug_toolbar.urls)),
+    path('rosetta/', include('rosetta.urls'))
 ]
+

--- a/saskatoon/sitebase/templates/app/base/header.html
+++ b/saskatoon/sitebase/templates/app/base/header.html
@@ -50,6 +50,7 @@
                                                 {% translate "Manage beneficiary" %}</a></li>
                                         {% endif %}
                                         <li><a href="/admin/">{% translate "Admin panel" %}</a></li>
+                                        <li><a href="/rosetta/">{% translate "Manage translations" %}</a></li>
                                     </ul>
                                 </li>
                             {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "django-redis",
         "django-dotenv",
         "django-crispy-forms",
+        "django-rosetta==0.9.8"
     ],
     extras_require      =   {
         'test': ['pytest', 'selenium', 'pytest-django', 'invoke', 'tox']


### PR DESCRIPTION
Install Rosetta to manage translations in human friendly way

fixes:#121

Screenshots: 

<img width="720" alt="rosetta" src="https://user-images.githubusercontent.com/48182195/160218960-a02ad90a-e1c8-4089-bffe-d02dfd3e720b.png">
<img width="233" alt="manage translation" src="https://user-images.githubusercontent.com/48182195/160253691-0ed15c03-67c7-42be-beab-3199169a1486.png">



Signed-off-by: Jayati Shrivastava <gaurijove@gmail.com>