### PR TITLE
Add "<4.0.0" for Django required version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "asgiref>=3.2.7",
         "cffi==1.14.0",
         "cryptography>=3.3.2",
-        "Django>=3.0.14",
+        "Django>=3.0.14,<4.0.0",
         "django-geojson==3.0.0",
         "django-leaflet==0.26.0",
         "django-rest-knox==4.1.0",


### PR DESCRIPTION
After using `pip3 install .` while following `INSTALL.md`, Django 4.0.3 got installed for some reason.
After running `python3 saskatoon/manage.py migrate --skip-checks`, I got an import error most probably because of version incompatibility.
So adding this restriction will prevent the behavior that occurred to me.