### PR TITLE
Admin panel list displays improvement for Property (harvest app) and Person (member app) - new

### DIFF
--- a/saskatoon/member/admin.py
+++ b/saskatoon/member/admin.py
@@ -5,6 +5,8 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.forms import (UserCreationForm, UserChangeForm,
                                         ReadOnlyPasswordHashField)
+from django.db.models import Value
+from django.db.models.functions import Replace
 from member.models import (AuthUser, Actor, Language, Person, Organization,
                            Neighborhood, City, State, Country)
 from member.filters import GroupFilter, PropertyFilter, PickLeaderFilter, VolunteerFilter
@@ -205,11 +207,45 @@ class AuthUserAdmin(UserAdmin):
     ]
 
 
+class PersonAdmin(admin.ModelAdmin):
+    list_display = (
+        '__str__',
+        'phone',
+        'email',
+        'street_number',
+        'street',
+        'neighborhood',
+        'postal_code',
+        'newsletter_subscription',
+        'language',
+    )
+    list_filter = (
+        'neighborhood',
+        'city',
+        'language',
+        'newsletter_subscription',
+    )
+    search_fields = (
+        'first_name',
+        'family_name',
+        'phone',
+        'postal_code_cleaned',
+        'auth_user__email',
+    )
+
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        queryset = queryset.annotate(
+            postal_code_cleaned=Replace('postal_code', Value(" "), Value(""))
+        )
+        return queryset
+
+
 # admin.site.register(Notification)
 # admin.site.register(AuthUserAdmin)
 admin.site.register(Actor)
 admin.site.register(Language)
-admin.site.register(Person)
+admin.site.register(Person, PersonAdmin)
 admin.site.register(Organization)
 admin.site.register(Neighborhood)
 admin.site.register(City)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "asgiref>=3.2.7",
         "cffi>=1.14.0",
         "cryptography>=3.3.2",
-        "Django>=3.0.14",
+        "Django>=3.0.14,<4.0.0",
         "django-geojson==3.0.0",
         "django-leaflet==0.26.0",
         "django-rest-knox==4.1.0",


### PR DESCRIPTION
Added relevant fields in list_display, list_filter and search_fields for Property (harvest app) and Person (member app) in Django admin.

Links to check after running locally -

[http://localhost:8000/admin/harvest/property/](http://localhost:8000/admin/harvest/property/)
[http://localhost:8000/admin/member/person/](http://localhost:8000/admin/member/person/)

Screenshots -

For Property model -

![property-new](https://user-images.githubusercontent.com/43474661/160253225-181e5832-b2f2-423a-9112-8a9a25b63f4b.png)

For Person model -

![person-new](https://user-images.githubusercontent.com/43474661/160253240-9c69e77b-49e6-418e-a9bc-e50205a1a7ff.png)

Intended fix for [#119](https://github.com/LesFruitsDefendus/saskatoon-ng/issues/119)

Also made the change to keep Django version under 4.0.0 to solve ImportError of 'force_text' from 'django.utils.encoding'.