### PR TITLE
[fix #32] Added success message if harvest status updated to "Succeeded"

### DIFF
--- a/saskatoon/harvest/views.py
+++ b/saskatoon/harvest/views.py
@@ -1,8 +1,10 @@
 from django.utils.translation import ugettext_lazy as _
+from django.utils import timezone
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.contrib.auth.decorators import login_required
+from django.contrib.humanize.templatetags.humanize import ordinal
 
 from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
@@ -131,6 +133,21 @@ class HarvestUpdateView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
         context['title'] = _("Edit harvest")
         context['cancel_url'] = reverse_lazy('harvest-detail', kwargs={'pk': self.object.pk})
         return context
+
+    def get_success_message(self, cleaned_data) -> str:
+        harvests_as_pickleader = self.object.pick_leader.person.harvests_as_pickleader
+        harvests_this_year = harvests_as_pickleader.filter(
+            start_date__year=timezone.now().date().year
+        )
+        harvest_number: int = harvests_this_year.count()
+
+        success_message_harvest_successful: str = _(
+            "You’ve just led your {} fruit harvest! Thank you for supporting your community!"
+        ).format(ordinal(harvest_number))
+
+        if self.object.status == "Succeeded":
+            return success_message_harvest_successful % cleaned_data
+        return self.success_message % cleaned_data
 
     def get_success_url(self):
             return reverse_lazy('harvest-detail', kwargs={'pk': self.object.pk})


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please note that util PR #114 is merged, all new pull requests should target the ``develop`` branch.  
-->
fixes #32 
---------------------
After Editing Harvest on `/harvest/update/<pk>` and setting Harvest status to "Succeeded":

![image](https://user-images.githubusercontent.com/52796958/160337273-335246bf-7c95-479c-99f3-7653a3594c5b.png)
----------
On the success url, the success message changes to "You’ve just led your `harvest's pick-author successful number of harvests` fruit harvest this season! Thank you for supporting your community!":

![image](https://user-images.githubusercontent.com/52796958/160337477-1343e81c-5c18-4f46-96a1-7824faaab088.png)
