### PR TITLE
Fix for datetimepicker inside season filter on harvest page

### DIFF
--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -39,7 +39,7 @@ class HarvestViewset(LoginRequiredMixin, viewsets.ModelViewSet):
                         'property',
                         'about',
                         'status',
-                        'start_date')
+                        'season')
 
     # Harvest detail
     def retrieve(self, request, format='html', pk=None):

--- a/saskatoon/harvest/filters.py
+++ b/saskatoon/harvest/filters.py
@@ -19,7 +19,8 @@ class HarvestFilter(filters.FilterSet):
     seasons = list(set(seasons))
     seasons = sorted(seasons, key=lambda tup: tup[1])
 
-    start_date = filters.ChoiceFilter(
+    season = filters.ChoiceFilter(
+        field_name='start_date', 
         choices=seasons,
         label=_("Season"),
         lookup_expr='year',
@@ -55,13 +56,13 @@ class HarvestFilter(filters.FilterSet):
 
     class Meta:
         model = Harvest
-        fields = {
-        'status': ['exact'],
-        'pick_leader': ['exact'],
-        'trees': ['exact'],
-        'property__neighborhood': ['exact'],
-        'start_date': ['exact'],
-        }
+        fields = (
+            'status',
+            'pick_leader',
+            'trees',
+            'property__neighborhood',
+            'season',
+        )
 
 
 class PropertyFilter(filters.FilterSet):


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please note that util PR #114 is merged, all new pull requests should target the ``develop`` branch.  
-->
Intended fix for [#123](https://github.com/LesFruitsDefendus/saskatoon-ng/issues/123)

The issue was the ID of the season filter field is "id_start_date" which is automatically generated by [django-crispy-forms](https://github.com/django-crispy-forms/django-crispy-forms) based on the field name and it's the same ID as the "Start date" field that's on the "Add a new harvest" form / page where the datetimepicker was originally intended for. 

To initiate the datetimepicker, the following code was included in `saskatoon/sitebase/templates/app/base/scripts.html` file - 

```
$("#id_start_date").datetimepicker({
     format: 'd/m/Y H:i',
 });
```

Since the above code is in a base template that other templates are inheriting from, it was also active on the "Harvests" page. Since it's not intended to be executed on this specific page, I have added a condition to check the URL of the current page using jQuery and if it's path is `/harvests/`, the datetimepicker is not executed anymore.