### PR TITLE
Add "under development" notes for Statistics page

### DIFF
--- a/saskatoon/sitebase/templates/app/base/view.html
+++ b/saskatoon/sitebase/templates/app/base/view.html
@@ -39,17 +39,19 @@
         {% include 'app/base/menu.html' %}
     {% endif %}
 
-    {% if messages %}
-    <div class="container">
-        <div class="row">
-            <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
-                    {% for message in messages %}
-                <div class="text-center alert alert-{{message.tags}}" role="alert">{{ message|safe }}</div>
-                {% endfor %}
+    {% block message %}
+        {% if messages %}
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
+                        {% for message in messages %}
+                    <div class="text-center alert alert-{{message.tags}}" role="alert">{{ message|safe }}</div>
+                    {% endfor %}
+                </div>
             </div>
         </div>
-    </div>
-    {% endif %}
+        {% endif %}
+    {% endblock message %}
 
     <!-- Content -->
     {% block content %}

--- a/saskatoon/sitebase/templates/app/base/view.html
+++ b/saskatoon/sitebase/templates/app/base/view.html
@@ -10,7 +10,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>Saskatoon - Les Fruits Défendus</title>
+    <title>{% block title %}Saskatoon - Les Fruits Défendus{% endblock %}</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" type="image/x-icon" href="{% static 'img/favicon.ico' %}">

--- a/saskatoon/sitebase/templates/app/stats.html
+++ b/saskatoon/sitebase/templates/app/stats.html
@@ -2,6 +2,10 @@
 {% load i18n %}
 {% load static %}
 
+<head>
+    <title>{% block title %}UNDER DEVELOPMENT{% endblock title %}</title>
+</head>
+
 {% block content %}
 
     <!-- Start Status area -->

--- a/saskatoon/sitebase/templates/app/stats.html
+++ b/saskatoon/sitebase/templates/app/stats.html
@@ -6,6 +6,16 @@
     <title>{% block title %}UNDER DEVELOPMENT{% endblock title %}</title>
 </head>
 
+{% block message %}
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
+                <div class="text-center alert alert-danger" role="alert">Statistics Page is Under Development. Please check the page's <a href="https://github.com/LesFruitsDefendus/saskatoon-ng/issues?q=is%3Aissue+is%3Aopen+statistics" target="_blank" rel="noopener noreferrer">issues</a></div>
+            </div>
+        </div>
+    </div>
+{% endblock message %}
+
 {% block content %}
 
     <!-- Start Status area -->


### PR DESCRIPTION
Fixes #16
------------------
Screenshot: (`localhost/stats/`)
![image](https://user-images.githubusercontent.com/52796958/160988158-ab7d6cf8-9604-4cdc-a2b4-256d16c2cbe6.png)
