### PR TITLE
added python-dotenv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
         "django-rosetta==0.9.8"
     ],
     extras_require      =   {
-        'test': ['pytest', 'selenium', 'pytest-django', 'invoke', 'tox']
+        'test': ['pytest', 'selenium', 'pytest-django', 'invoke', 'tox', 'python-dotenv']
     },
 )


### PR DESCRIPTION
python-dotenv is used for testing but wasn't added to the `setup.py`. 
![2022-04-01_21-56](https://user-images.githubusercontent.com/57852546/161340708-1494b2c5-7cd2-44e6-9e23-7c1db6746838.png)


I added it in this pull request.

<!-- 
Thanks for your contribution!
-->
