### PR TITLE
[#34] Add support for email notification to tree owner

### DIFF
--- a/saskatoon/harvest/models.py
+++ b/saskatoon/harvest/models.py
@@ -774,6 +774,11 @@ models.signals.pre_save.connect(
     sender=Property
 )
 
+models.signals.pre_save.connect(
+    receiver=signals.notify_pending_status_update,
+    sender=Property
+)
+
 models.signals.post_save.connect(
     receiver=signals.clear_cache_property,
     sender=Property

--- a/saskatoon/harvest/signals.py
+++ b/saskatoon/harvest/signals.py
@@ -2,6 +2,7 @@ from crequest.middleware import CrequestMiddleware
 from django.core.mail import send_mail
 from django.core.cache import cache
 from saskatoon.settings import SEND_MAIL_FAIL_SILENTLY
+from django.utils.translation import gettext_lazy as _
 
 def clear_cache_property(sender, instance, **kwargs):
     cache.delete_pattern("*property*")
@@ -36,6 +37,45 @@ def changed_by(sender, instance, **kwargs):
             instance.changed_by = current_request.user
     else:
         instance.changed_by = None
+
+def notify_pending_status_update(sender, instance, **kwargs):
+    # Send email only if pending status is removed
+    if instance.id:
+        original_instance = sender.objects.get(id=instance.id)
+        if original_instance.pending and not instance.pending:
+            property_owner_email = list()
+            if instance.owner:
+                    if not instance.owner.is_person and not instance.owner.is_organization:
+                        # TODO: log this warning in a file
+                        print(f"Property owner is neither a person nor an organization. " \
+                             f"Unknown Actor: {instance.owner.actor_id}")
+                        return
+                    property_owner_name = instance.get_owner_name
+                    contact_email = instance.get_owner_email
+            else:
+                property_owner_name = instance.pending_contact_name
+                contact_email = instance.pending_contact_email
+            if not property_owner_name or not len(property_owner_name):
+                # TODO: log this warning in a file
+                print("Property Owner information is missing")
+                return
+            if not contact_email or not len(contact_email):
+                # TODO: log this warning in a file
+                print("Property Owner contact email information is missing")
+                return
+            property_owner_email.append(contact_email)
+            mail_subject = _("Property Validation Completed")
+            message = (_("Hi") + " " + property_owner_name + ",\n\n" +
+                    _("Your tree subscription has been validated by " +
+                    "a member of Les Fruits Défendus. ") +
+                    _("A pick leader might contact you to plan a " +
+                    "harvest this season.") + "\n\n" +
+                    _("Thanks for supporting your community!") + "\n\n" +
+                    _("Yours") + ",\n" +
+                    "--\n" +
+                    "Saskatoon Harvest System")
+
+            _send_mail(mail_subject, message, property_owner_email)
 
 def comment_send_mail(sender, instance, **kwargs):
     current_request = CrequestMiddleware.get_request()


### PR DESCRIPTION
Adds support for email notification to tree owner when pending status is removed by administrator.

Fixes #34 
Depends on #213 

Signed-off-by: Jayati Shrivastava <gaurijove@gmail.com>

<!-- 
Thanks for your contribution!
-->
