### PR TITLE
Add TreeTypeSerializer for other views

### DIFF
--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -61,7 +61,6 @@ class HarvestViewset(LoginRequiredMixin, viewsets.ModelViewSet):
         property = harvest.property
         pickers = [harvest.pick_leader] + [r.picker for r in requests.filter(is_accepted=True)]
         organizations = Organization.objects.filter(is_beneficiary=True)
-        trees = harvest.trees.all()
 
         return Response({'harvest': response.data,
                          'harvest_date': harvest.get_local_start().strftime("%a. %b. %-d, %Y"),
@@ -76,7 +75,6 @@ class HarvestViewset(LoginRequiredMixin, viewsets.ModelViewSet):
                          'property': property,
                          'pickers': pickers,
                          'organizations': organizations,
-                         'trees': trees,
                          'form_edit_recipient': HarvestYieldForm(),
                         })
 

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/distribution/tree_select.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/distribution/tree_select.html
@@ -1,7 +1,8 @@
 {% load static %}
+{% load get_fruit_name_icon %}
 
 <select name="tree" id="tree-select" class="form-control">
-    {% for t in trees %}
-        <option value="{{ t.id }}">{{ t }}</option>
+    {% for t in harvest.trees %}
+        <option value="{{ t.id }}">{{ t.name }} {{ t.fruit_name|get_fruit_name_icon }}</option>
     {% endfor %}
 </select>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/distribution/view.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/distribution/view.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load i18n %}
+{% load get_fruit_name_icon %}
 
 <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12">
     <div class="sale-statistic-inner notika-shadow mg-tb-30">
@@ -18,7 +19,7 @@
                         {% for d in distribution %}
                         <tr>
                             <td> {{ d.recipient }} </td>
-                            <td> {{ d.tree.fruit_name }} </td>
+                            <td> {{ d.tree.fruit_name }} {{ d.tree.fruit_name|get_fruit_name_icon }}</td>
                             <td> {{ d.total_in_lb }} lbs</td>
                             <td class="text-center">
                                 <a href="/yield/delete/{{d.id}}/"


### PR DESCRIPTION
fixes #192
-----------
##  What's Fixed:
1. Used `TreeTypeSerializer` (`harvest.trees`) in `tree_select.html` instead of `trees`. 6469a0376fe67e89425434456ee43b2ed7e01dd0
2. Removed the unused `trees` variable (check screenshot 1). 416b22e907bad9581431115fd2300e8e2940de31
3. Used `get_fruit_name_icon` template filter in `detail_views/harvest/distribution/view.html` (check screenshot 2). e1574e8721ff921a1625b8dc2142e90e72324d84

------------
## Screenshots:
1. 
![image](https://user-images.githubusercontent.com/52796958/161886914-f7f8a5d6-9e6b-4b83-9eed-8a2bfd5bb563.png)
2. 
![image](https://user-images.githubusercontent.com/52796958/161887091-ae2043b1-1a5e-411f-906f-d38f8e22ca13.png)

-----------
## URLs:
- `http://localhost/harvest/<pk>/`
