### PR TITLE
[#222] Fix PersonCreateForm validation

### DIFF
--- a/saskatoon/member/forms.py
+++ b/saskatoon/member/forms.py
@@ -40,7 +40,7 @@ class PersonCreateForm(forms.ModelForm):
     field_order = ['roles', 'first_name', 'family_name', 'email', 'language']
 
     def clean(self):
-        cleaned_data = super(PersonCreateForm, self).clean()
+        cleaned_data = super().clean()
         validate_email(cleaned_data['email'])
 
     def save(self):
@@ -52,11 +52,12 @@ class PersonCreateForm(forms.ModelForm):
                 email=self.cleaned_data['email'],
                 person=instance
         )
-        auth_user.set_roles(self.cleaned_data['roles'])
+        roles = self.cleaned_data['roles']
+        auth_user.set_roles(roles)
 
         # associate pending_property (if any)
         pid = self.cleaned_data['pending_property_id']
-        if pid:
+        if pid and 'owner' in roles:
             try:
                 pending_property = Property.objects.get(id=pid)
                 pending_property.owner = instance

--- a/saskatoon/member/forms.py
+++ b/saskatoon/member/forms.py
@@ -39,8 +39,9 @@ class PersonCreateForm(forms.ModelForm):
 
     field_order = ['roles', 'first_name', 'family_name', 'email', 'language']
 
-    def clean_email(self):
-        return validate_email(self.cleaned_data['email'])
+    def clean(self):
+        cleaned_data = super(PersonCreateForm, self).clean()
+        validate_email(cleaned_data['email'])
 
     def save(self):
         # create Person instance

--- a/saskatoon/member/views.py
+++ b/saskatoon/member/views.py
@@ -24,7 +24,7 @@ class PersonCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateView)
             initial = { 'roles': ['owner'],
                         'first_name': p.pending_contact_first_name,
                         'family_name': p.pending_contact_family_name,
-                        'phone': p.pending_contact_phone.replace(" ", "-"),
+                        'phone': p.pending_contact_phone,
                         'email': p.pending_contact_email,
                         'street_number': p.street_number,
                         'street': p.street,

--- a/saskatoon/member/views.py
+++ b/saskatoon/member/views.py
@@ -56,6 +56,11 @@ class PersonCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateView)
         except KeyError:
             return reverse_lazy('community-list')
 
+    def form_invalid(self, form, **kwargs):
+        context = self.get_context_data(**kwargs)
+        context['form'] = form
+        return self.render_to_response(context)
+
 class PersonUpdateView(PermissionRequiredMixin, SuccessMessageMixin, UpdateView):
     permission_required = 'member.change_person'
     model = Person


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
-->
Fixes [#222](https://github.com/LesFruitsDefendus/saskatoon-ng/issues/222)

After submitting the form with an email already existing in the database, there was no `POST` request showing up on the console (`python saskatoon/manage.py runserver`). The issue was probably when the form was submitted and it was invalid, it wasn't handled properly. To fix this I have used `form_invalid` method in `PersonCreateView` to handle the invalid form.

After this there is the `POST` request showing up on the console after submitting the form with an email that already exists in the database -

![Screenshot from 2022-04-11 13-00-21 png-mh](https://user-images.githubusercontent.com/43474661/162683717-c0fe0800-8ed2-4e13-8b43-43caa594e452.png)

But this change still wasn't showing the errors. To fix this, I have changed `clean_email` method under `PersonCreateForm` to the default `clean` method and updated as needed. Now it shows the errors on the page.

![Screenshot from 2022-04-11 12-56-24](https://user-images.githubusercontent.com/43474661/162684369-e79053ed-d826-4d4a-99a3-6b6f39145123.png)

Also work in progress for issue [#221](https://github.com/LesFruitsDefendus/saskatoon-ng/issues/221)