### PR TITLE
postal_code field validation on PublicPropertyForm

### DIFF
--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -11,6 +11,7 @@ from harvest.models import (RequestForParticipation, Harvest, HarvestYield, Comm
                             Equipment, PropertyImage, HarvestImage, TreeType, Property)
 from member.forms import validate_email
 from member.models import AuthUser, Person, Organization
+from postalcodes_ca import parse_postal_code
 
 # Request for participation
 class RequestForm(forms.ModelForm):
@@ -469,6 +470,18 @@ class PublicPropertyForm(forms.ModelForm):
         widget=forms.widgets.Textarea(),
         required=False
     )
+
+    def clean(self):
+        cleaned_data = super(PublicPropertyForm, self).clean()
+        postal_code = cleaned_data['postal_code'].replace(" ", "")
+
+        try:
+            postal_code = parse_postal_code(postal_code)
+        except ValueError as invalid_postal_code:
+            raise forms.ValidationError(str(invalid_postal_code))
+            
+        cleaned_data['postal_code'] = postal_code
+        return cleaned_data
 
 class HarvestForm(forms.ModelForm):
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
         "django-dotenv",
         "django-crispy-forms",
         "django-rosetta==0.9.8",
-        "django-phone-field==1.8.1"
+        "django-phone-field==1.8.1",
+        "postalcodes-ca==0.0.9"
     ],
     extras_require      =   {
         'test': ['pytest', 'selenium', 'pytest-django', 'invoke', 'tox']


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
-->
Partially addresses [#116](https://github.com/LesFruitsDefendus/saskatoon-ng/issues/116)

Added form validation for `postal_code` field in `PublicPropertyForm` form using [postalcodes-ca](https://github.com/verhovsky/postalcodes-ca) package.

Some screenshots showing different error messages for invalid postal code inputs -

![Screenshot from 2022-04-11 15-56-19](https://user-images.githubusercontent.com/43474661/162715986-3ba879b5-b9b4-4c94-97b0-edc4e9298483.png)

![Screenshot from 2022-04-11 15-56-35](https://user-images.githubusercontent.com/43474661/162716057-447aab6a-aa78-4d5b-bdd5-3731e92ee2ab.png)

![Screenshot from 2022-04-11 15-56-45](https://user-images.githubusercontent.com/43474661/162716066-2e855421-f0d4-415f-a3ef-1256f7e97f8d.png)

![Screenshot from 2022-04-11 15-57-30](https://user-images.githubusercontent.com/43474661/162716082-2bffee56-319d-4e67-9e7a-4ffefd1e39e0.png)

