### PR TITLE
[#226] Fix IntegrityError on PublicPropertyForm

### DIFF
--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -470,6 +470,14 @@ class PublicPropertyForm(forms.ModelForm):
         required=False
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['avg_nb_required_pickers'].widget.attrs['min'] = 1
+        self.fields['number_of_trees'].widget.attrs['min'] = 1
+        self.fields['fruits_height'].widget.attrs['min'] = 1
+        self.fields['street_number'].widget.attrs['min'] = 0.0
+        self.fields['complement'].widget.attrs['min'] = 0.0
+
 class HarvestForm(forms.ModelForm):
 
     class Meta:


### PR DESCRIPTION
Fixes [#226](https://github.com/LesFruitsDefendus/saskatoon-ng/issues/226)

Added `min_value` for the fields that were causing the error -

`avg_nb_required_pickers`
`number_of_trees`
`fruits_height`

Added `min_value` for the fields that logically shouldn't allow negative numbers - 

`street_number`
`complement`

<!-- 
Thanks for your contribution!
-->
