### PR TITLE
Add Harvest column in property detail view

### DIFF
--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -112,7 +112,7 @@ class PropertyHarvestSerializer(serializers.ModelSerializer):
 
     def get_pick_leader(self, harvest):
         if harvest.pick_leader:
-            return harvest.pick_leader.person.first_name
+            return PersonSerializer(harvest.pick_leader.person).data
         return None
 
 

--- a/saskatoon/sitebase/templates/app/detail_views/property/harvest_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/harvest_row.html
@@ -1,7 +1,37 @@
 {% load i18n %}
 {% load static %}
 <tr>
-    <td>{{ harvest.pick_leader__person__first_name }}</td>
+    <td>
+        <a href='{% url "harvest-detail" harvest.id %}'>#{{ harvest.id }} Harvest by {{ harvest.pick_leader.name }}</a>
+        {% if perms.harvest.delete_harvest %}
+            &nbsp;
+            <small>
+                <a href="{% url 'harvest_delete' harvest.id %}"
+                onclick="return confirm('{% trans "Are you really sure you want to delete this harvest?" %}');"
+                    <i class="fa fa-trash text-danger"></i>
+                </a>
+            </small>
+        {% endif %}
+    </td>
+    <td>
+        <b>{{ harvest.pick_leader.name }}</b>
+
+        {% if perms.member.change_person %}
+            &nbsp;
+            <small><a href="{% url 'person-update' harvest.pick_leader.actor_id %}"
+                    title="edit">
+                <i class="fa fa-pencil"></i>
+            </a></small>
+        {% endif %}
+        {% if harvest.pick_leader.phone %}
+            <br> <i class="fa fa-mobile text-muted"></i>&nbsp;
+            {{ harvest.pick_leader.phone }}
+        {% endif %}
+        <br>
+        <a href="mailto:{{harvest.pick_leader.email}}">
+            {{ harvest.pick_leader.email }}
+        </a>
+    </td>
     <td>
         {% if harvest.status == "Succeeded" %}
         <div class="skill">

--- a/saskatoon/sitebase/templates/app/detail_views/property/harvest_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/harvest_table.html
@@ -22,6 +22,7 @@
                         <table class="table table-striped" id="data-table-basic">
                             <thead>
                             <tr>
+                                <th style="width: 20%">{% trans "Harvest" %}</th>
                                 <th style="width: 12%">{% trans "Pickleader" %}</th>
                                 <th style="width: 12%">{% trans "Status" %}</th>
                                 <th style="width: 20%">{% trans "Date" %}</th>


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->
Fixes #157
----------
## Type of change:
- [x] New feature (change which adds functionality).
----------
## What's Changed:
- Made `PropertyHarvestSerializer` use `PersonSerializer` for harvests' pickleader data.
- Added a column for the harvests table in the property detail view that contains the harvest's link and a delete button.
- Added more info on the pickleader column.

--------
## Screenshots:
1.
![image](https://user-images.githubusercontent.com/52796958/169346903-eded86d7-df32-47b3-ab35-bcf2d6225ec6.png)

--------
## Affected URLs:
`127.0.0.1:8000/property/<pk>`

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.