### PR TITLE
Fix template errors

### DIFF
--- a/saskatoon/sitebase/templates/app/detail_views/harvest/distribution/create_yield.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/distribution/create_yield.html
@@ -1,4 +1,6 @@
 {% load static %}
+{% load i18n %}
+
 <table class="table">
     <tr>
         <!-- cols should add up to 12... -->

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/distribution/recipient_select.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/distribution/recipient_select.html
@@ -1,4 +1,6 @@
 {% load static %}
+{% load i18n %}
+
 <select name="actor" id="recipient-select" class="form-control required">
     <option selected disabled>{% translate 'Owner' %}</option>
     <option value={{ property.owner.pk }}>{{ property.owner }}</option>

--- a/saskatoon/tests/README.md
+++ b/saskatoon/tests/README.md
@@ -5,6 +5,7 @@ Run
 
 ```
 ./saskatoon/manage.py check --database default
+./saskatoon/manage.py validate_templates
 ```
 
 # Selenium-driven tests


### PR DESCRIPTION
```
./saskatoon/manage.py validate_templates
```

Discovered 2 errors. 

<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->

----------
## Type of change:
- [x] Bug fix (change which fixes an issue).
----------
## What's Changed:
- fixed missing imports in the 2 templates

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
