### PR TITLE
Fix calendar path

### DIFF
--- a/saskatoon/sitebase/urls.py
+++ b/saskatoon/sitebase/urls.py
@@ -1,13 +1,13 @@
 from django.conf.urls import include, url
 from django.contrib.auth import views as auth_views
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, re_path
 from sitebase import views
 
 urlpatterns = [
 
     url(r'^$', views.Index.as_view(), name='home'),
-    url(r'^calendar$', views.Calendar.as_view(), name='calendar'),
+    re_path(r'^calendar/$', views.Calendar.as_view(), name='calendar'),
     url(r'^jsoncal', views.JsonCalendar.as_view(), name='calendarJSON'),
 
     path('reset_password/',


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->
Fixes #245
----------
## Type of change:
- [x] Bug fix (change which fixes an issue).
- [ ] New feature (change which adds functionality).
- [ ] Changes to models (requires making migrations).
- [ ] Documentation change.
----------
## What's Changed:
- Used `re_path()` instead of `url()` for the calendar path
--------
## Screenshots:
1.
![image](https://user-images.githubusercontent.com/52796958/163443498-30809577-fa28-4d3b-83f6-481ccc98fb62.png)
--------
## Affected URLs:
e.g. `http://127.0.0.1:8000/calendar/`

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
