### PR TITLE
[#243] Remove useless chart in harvest page

### DIFF
--- a/saskatoon/sitebase/templates/app/detail_views/harvest/about.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/about.html
@@ -39,7 +39,7 @@
                         <tr>
                             <td>{% trans "Adresss" %}</td>
                             <td class="text-right">
-                                <h4>{{ harvest.property.address }}</h4>
+                                <h4><a href="/property/{{harvest.property.id}}">{{ harvest.property.address }}</a></h4>
                             </td>
                         </tr>
                         <tr>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
@@ -32,7 +32,6 @@
                             <p>{% trans "Total harvested:" %}</p>
                             <h2><span class="counter">{{ harvest.total_distribution|unlocalize }}</span> lbs</h2>
                         </div>
-                        <div class="sparkline-bar-stats1">9,4,8,6,5,6,4,8,3,5,9,5</div>
                     {% else %}
                         <div class="website-traffic-ctn">
                             <p>{% trans "Pickers requests" %}</p>


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->
Fixes [#243](https://github.com/LesFruitsDefendus/saskatoon-ng/issues/243) and [#242](https://github.com/LesFruitsDefendus/saskatoon-ng/issues/242)
----------
## Type of change:
- [x] Bug fix (change which fixes an issue).
- [x] New feature (change which adds functionality).
----------
## What's Changed:
- Useless chart removed from harvest detail view (from total harvested status)
- Updated link to the property record from the harvest record

--------
## Screenshots:
![Screenshot from 2022-04-15 00-12-06](https://user-images.githubusercontent.com/43474661/163452120-a225e9ac-7df1-44d8-a5c6-8ffbeae22c95.png)

--------
## Affected URLs:
`127.0.0.1:8000/harvest/<int:pk>/`

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.

Unit tests didn't pass for this because I have used a different head `ebc6660b5c996463245472eb294161df38cc33bd` which was before the tests were fixed to avoid [#247](https://github.com/LesFruitsDefendus/saskatoon-ng/issues/247)