### PR TITLE
Fix loading order of fixtures in the fixtures/init script

### DIFF
--- a/saskatoon/fixtures/init
+++ b/saskatoon/fixtures/init
@@ -2,12 +2,12 @@
 
 # Load initial fixtures from .json files
 
+# automatically exit on error
+set -e
+
 # get script directory no matter where it's called from (doesn't work w/ symlinks)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd $SCRIPT_DIR
-
-# automatically exit on error
-set -e
 
 # migrate database in case it was not already done
 ../manage.py migrate --skip-checks

--- a/saskatoon/fixtures/init
+++ b/saskatoon/fixtures/init
@@ -23,9 +23,9 @@ seq=(auth-group \
      member-person \
      member-organization \
      member-authuser \
+     harvest-treetype \
      harvest-property \
      harvest-equipmenttype \
-     harvest-treetype \
      harvest-equipment \
      harvest-harvest \
      harvest-harvestyield \

--- a/saskatoon/fixtures/init
+++ b/saskatoon/fixtures/init
@@ -30,25 +30,12 @@ seq=(auth-group \
      harvest-harvest \
      harvest-harvestyield \
      harvest-comment \
-     harvest-requestforparticipation \
-    )
-
-ignore="-e ^saskatoon"
+     harvest-requestforparticipation )
 
 # fixtures defined in sequence
 for fix in "${seq[@]}"
 do
     echo "Loading $fix"
     ./loaddata $fix
-    ignore="$ignore -e ^$fix"
+
 done
-
-# unused .json files
-unused=$(ls *.json | grep -v $ignore)
-echo "Unused .json fixtures:"; echo $unused
-
-# for fix in $unused
-# do
-#     echo "Loading $fix"
-#     ./loaddata $fix
-# done

--- a/saskatoon/fixtures/init
+++ b/saskatoon/fixtures/init
@@ -13,8 +13,7 @@ cd $SCRIPT_DIR
 ../manage.py migrate --skip-checks
 
 # initial sequence order does matter!
-seq=(auth-group \
-     member-city \
+seq=(auth-group member-city \
      member-neighborhood \
      member-state \
      member-country \
@@ -32,10 +31,22 @@ seq=(auth-group \
      harvest-comment \
      harvest-requestforparticipation )
 
+ignore='saskatoon'
+
 # fixtures defined in sequence
 for fix in "${seq[@]}"
 do
     echo "Loading $fix"
     ./loaddata $fix
-
+    ignore+="\\|$fix"
 done
+
+# unused .json files
+unused=$(ls *.json | sed "/$ignore/!d")
+if [[ -n "$unused" ]]; then
+    echo "Unused .json fixtures:"
+    echo "$unused"
+    exit 4
+else
+    echo 'No unused fixtures.'
+fi

--- a/saskatoon/fixtures/init
+++ b/saskatoon/fixtures/init
@@ -31,14 +31,14 @@ seq=(auth-group member-city \
      harvest-comment \
      harvest-requestforparticipation )
 
-ignore='saskatoon'
+ignore='saskatoon\.json'
 
 # fixtures defined in sequence
 for fix in "${seq[@]}"
 do
     echo "Loading $fix"
     ./loaddata $fix
-    ignore+="\\|$fix"
+    ignore+="\\|$fix\\.json"
 done
 
 # unused .json files

--- a/saskatoon/fixtures/init
+++ b/saskatoon/fixtures/init
@@ -42,7 +42,7 @@ do
 done
 
 # unused .json files
-unused=$(ls *.json | sed "/$ignore/!d")
+unused=$(ls *.json | sed -n "/$ignore/s///gp")
 if [[ -n "$unused" ]]; then
     echo "Unused .json fixtures:"
     echo "$unused"

--- a/saskatoon/fixtures/loaddata
+++ b/saskatoon/fixtures/loaddata
@@ -8,6 +8,9 @@
 # - all fixtures     $ ./loaddata all
 # - whole database   $ ./loaddata saskatoon
 
+# automatically exit on error
+set -e
+
 # get script directory no matter where it's called from (doesn't work w/ symlinks)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
@@ -22,9 +25,9 @@ if [ $1 == "all" ]; then
     for f in $(ls *.json | grep -v "^saskatoon")
     do
         echo "Loading $f ..."
-        ../manage.py loaddata "${f%.*}" || exit 1
+        ../manage.py loaddata "${f%.*}"
     done
 else
-    ../manage.py loaddata $1 || exit 1
+    ../manage.py loaddata $1
 fi
 

--- a/saskatoon/manage.py
+++ b/saskatoon/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Django's command-line utility for administrative tasks."""
 import os
 import sys


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->

Fixes #268 (hopefully)
----------
## Type of change:
- [x] Bug fix (change which fixes an issue).
----------
## What's Changed:
- changed the order of the fixtures loading in the `saskatoon/fixtures/init `script.
- Improve the script to exit with code 4 if there are unused fixtures.

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
