### PR TITLE
Fixes  #172 without bootstrap 4

### DIFF
--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -478,6 +478,8 @@ class PublicPropertyForm(forms.ModelForm):
         self.fields['fruits_height'].widget.attrs['min'] = 1
         self.fields['street_number'].widget.attrs['min'] = 0.0
         self.fields['complement'].widget.attrs['min'] = 0.0
+        self.fields['pending_contact_phone'].widget.attrs.update({'class':'form-control'})
+
 
     def clean(self):
         cleaned_data = super(PublicPropertyForm, self).clean()

--- a/saskatoon/saskatoon/settings.py
+++ b/saskatoon/saskatoon/settings.py
@@ -226,7 +226,7 @@ CACHES = {
     }
 }
 
-CRISPY_TEMPLATE_PACK = 'bootstrap4'
+CRISPY_TEMPLATE_PACK = 'bootstrap3'
 
 CKEDITOR_CONFIGS = {
     'default': {


### PR DESCRIPTION
changed crispy_template_pack to use bootstrap 3 and changed the css classes on the contact phone number and ext model.
Here's what it looks like before
![contact](https://user-images.githubusercontent.com/78615753/163699419-195b953d-0445-48cd-8b1c-bec0a895bfde.png)

And after
![contact_after](https://user-images.githubusercontent.com/78615753/163699439-19f4753f-4115-436f-a708-34ca730f50c2.png)

Thereby completely resolving #172 conflicts of css styling issue for both error font and margin while still retaining the codebase use of bootstrap 3
