### PR TITLE
Refactor reversed urls

### DIFF
--- a/saskatoon/sitebase/templates/app/base/header.html
+++ b/saskatoon/sitebase/templates/app/base/header.html
@@ -27,7 +27,7 @@
                                     </span>
                                 </a>
                                 <ul class="dropdown-menu">
-                                    <li><a href="/admin/password_change/">{% translate "Change password" %}</a></li>
+                                    <li><a href="{% url 'admin:password_change' %}">{% translate "Change password" %}</a></li>
                                     <li><a href={% url "logout" %}>{% translate "Logout" %}</a></li>
                                 </ul>
                             </li>
@@ -38,25 +38,25 @@
                                     </a>
                                     <ul class="dropdown-menu">
                                         {% if perms.member.add_authuser %}
-                                            <li> <a href="/person/create/">
+                                            <li> <a href="{% url 'person-create' %}">
                                                 {% translate "Add user" %}</a></li>
                                         {% endif %}
                                         {% if perms.member.change_authuser %}
-                                            <li><a href="/admin/member/authuser/">
+                                            <li><a href="{% url 'admin:member_authuser_changelist' %}">
                                                 {% translate "Manage user" %}</a></li>
                                         {% endif %}
                                         {% if perms.member.change_organization %}
-                                            <li><a href="/admin/member/organization/">
+                                            <li><a href="{% url 'admin:member_organization_changelist' %}">
                                                 {% translate "Manage beneficiary" %}</a></li>
                                         {% endif %}
-                                        <li><a href="/admin/">{% translate "Admin panel" %}</a></li>
-                                        <li><a href="/rosetta/">{% translate "Manage translations" %}</a></li>
+                                        <li><a href="{% url 'admin:index' %}">">{% translate "Admin panel" %}</a></li>
+                                        <li><a href="{% url 'rosetta-old-home-redirect' %}">{% translate "Manage translations" %}</a></li>
                                     </ul>
                                 </li>
                             {% endif %}
                         {% else %}
                             <li>
-                                <a href='/login'>
+                                <a href='{% url 'login' %}'>
                                     <span class="menu-it-icon-pro">
                                         <span class="h5">{% translate 'login' %}</span>
                                         <i class="notika-icon notika-support"></i>

--- a/saskatoon/sitebase/templates/app/base/menu.html
+++ b/saskatoon/sitebase/templates/app/base/menu.html
@@ -10,25 +10,25 @@
                     <nav id="dropdown">
                         <ul class="mobile-menu-nav">
                             <li class="{% if request.resolver_match.url_name == 'calendar' %}active{% endif %}">
-                                <a href="/calendar">{% translate "Calendar" %} </a>
+                                <a href="{% url 'calendar' %}">{% translate "Calendar" %} </a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'harvest-list' %}active{% endif %}">
-                                <a href="/harvest">{% translate "Harvests" %} </a>
+                                <a href="{% url 'harvest-list' %}">{% translate "Harvests" %} </a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'property-list' %}active{% endif %}">
-                                <a href="/property">{% translate "Properties" %}</a>
+                                <a href="{% url 'property-list' %}">{% translate "Properties" %}</a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'beneficiary-list' %}active{% endif %}">
-                                <a href="/beneficiary">{% translate "Beneficiaries" %}</a>
+                                <a href="{% url 'beneficiary-list' %}">{% translate "Beneficiaries" %}</a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'community-list' %}active{% endif %}">
-                                <a href="/community">{% translate "Community" %}</a>
+                                <a href="{% url 'community-list' %}">{% translate "Community" %}</a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'equipment-list' %}active{% endif %}">
-                                <a href="/equipment">{% translate "Equipment" %}</a>
+                                <a href="{% url 'equipment-list' %}">{% translate "Equipment" %}</a>
                             </li>
                             <!-- <li class="{% if request.resolver_match.url_name == 'statistics' %}active{% endif %}">
-                                 <a href="/stats">{% translate "Statistics" %}</a>
+                                 <a href="{% url 'statistics' %}">{% translate "Statistics" %}</a>
                                  </li> -->
                         </ul>
                     </nav>
@@ -45,25 +45,25 @@
             <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
                 <ul class="nav nav-tabs tab-nav-center notika-menu-wrap menu-it-icon-pro">
                     <li class="{% if request.resolver_match.url_name == 'calendar' %}active{% endif %}">
-                        <a href="/calendar"><i class="fa fa-table"></i> {% translate "Calendar" %}</a>
+                        <a href="{% url 'calendar' %}"><i class="fa fa-table"></i> {% translate "Calendar" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'harvest-list' %}active{% endif %}">
-                        <a href="/harvest"><i class="fa fa-shopping-basket"></i> {% translate "Harvests" %}</a>
+                        <a href="{% url 'harvest-list' %}"><i class="fa fa-shopping-basket"></i> {% translate "Harvests" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'property-list' %}active{% endif %}">
-                        <a href="/property"><i class="glyphicon glyphicon-tree-deciduous"></i> {% translate "Properties" %}</a>
+                        <a href="{% url 'property-list' %}"><i class="glyphicon glyphicon-tree-deciduous"></i> {% translate "Properties" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'beneficiary-list' %}active{% endif %}">
-                        <a href="/beneficiary"><i class="fa fa-gift"></i> {% translate "Beneficiaries" %}</a>
+                        <a href="{% url 'beneficiary-list' %}"><i class="fa fa-gift"></i> {% translate "Beneficiaries" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'community-list' %}active{% endif %}">
-                        <a href="/community"><i class="fa fa-users"></i> {% translate "Community" %}</a>
+                        <a href="{% url 'community-list' %}"><i class="fa fa-users"></i> {% translate "Community" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'equipment-list' %}active{% endif %}">
-                        <a href="/equipment"><i class="fa fa-scissors"></i> {% translate "Equipment" %}</a>
+                        <a href="{% url 'equipment-list' %}"><i class="fa fa-scissors"></i> {% translate "Equipment" %}</a>
                     </li>
                     <!-- <li class="{% if request.resolver_match.url_name == 'statistics' %}active{% endif %}">
-                         <a href="/stats"><i class="fa fa-bar-chart fa-fw"></i> {% translate "Statistics" %}</a>
+                         <a href="{% url 'statistics' %}"><i class="fa fa-bar-chart fa-fw"></i> {% translate "Statistics" %}</a>
                          </li> -->
                 </ul>
             </div>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/about.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/about.html
@@ -27,7 +27,7 @@
                     <h2>{% translate 'Property information' %}
                     {% if perms.harvest.change_property %}
                         &nbsp;
-                        <a href="/property/update/{{harvest.property.id}}"
+                        <a href="{% url 'property-update' harvest.property.id %}"
                                 title="edit">
                             <i class="fa fa-pencil"></i>
                         </a>
@@ -39,7 +39,7 @@
                         <tr>
                             <td>{% trans "Adresss" %}</td>
                             <td class="text-right">
-                                <h4><a href="/property/{{harvest.property.id}}">{{ harvest.property.address }}</a></h4>
+                                <h4><a href="{% url 'property-detail' harvest.property.id %}">{{ harvest.property.address }}</a></h4>
                             </td>
                         </tr>
                         <tr>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/breadcomb.html
@@ -23,7 +23,7 @@
                         </div>
                         <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
                             <div class="breadcomb-report">
-                                <a href="/harvest/update/{{ harvest.id }}">
+                                <a href="{% url 'harvest-update' harvest.id %}">
                                     <button data-placement="left" title="Edit harvest" class="btn">
                                        {% trans "Edit Harvest" %}
                                     </button>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/comments.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/comments.html
@@ -10,7 +10,7 @@
                         </div>
                     </div>
                     <div class="col-xs-6">
-                        <a href="/comment/create?h={{ harvest.id }}"
+                        <a href="{% url 'comment-create' %}?h={{ harvest.id }}"
                            class="btn btn-success notika-btn-success waves-effect"
                            style="float: right">
                             <i class="fa fa-plus"></i> {% trans "New comment" %}

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/data_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/data_row.html
@@ -47,7 +47,7 @@
     <td>{{ r.comment }}</td>
     <td>{{ r.notes_from_pickleader }}</td>
     <td style="text-align: center;">
-        <a href="/participation/update/{{ r.id }}/?hid={{ harvest.id }}">
+        <a href="{% url 'participation-update' r.id %}?hid={{ harvest.id }}">
             <i class="fa fa-pencil"></i>
         </a>
     </td>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/data_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/data_table.html
@@ -13,7 +13,7 @@
                                 </div>
                             </div>
                             <div class="col-xs-6">
-                                <a href="/participation/create?hid={{ harvest.id }}"
+                                <a href="{% url 'rfp-create' %}?hid={{ harvest.id }}"
                                     class="btn btn-success notika-btn-success waves-effect"
                                     style="float: right">
                                     <i class="fa fa-plus"></i> {% trans "New request" %}

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/distribution/view.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/distribution/view.html
@@ -22,7 +22,7 @@
                             <td> {{ d.tree.fruit_name }} {{ d.tree.fruit_name|get_fruit_name_icon }}</td>
                             <td> {{ d.total_in_lb }} lbs</td>
                             <td class="text-center">
-                                <a href="/yield/delete/{{d.id}}/"
+                                <a href="{% url 'harvest-yield-delete' d.id %}"
                                    onclick="return confirm('{% trans "Are you sure you want to delete this entry?" %}');">
                                     <i class="fa fa-trash text-danger"></i>
                                 </a>

--- a/saskatoon/sitebase/templates/app/detail_views/property/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/breadcomb.html
@@ -37,7 +37,7 @@
                         <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
                             <div class="breadcomb-report">
                                 {% if perms.harvest.change_property %}
-                                    <a href="/property/update/{{ property.id }}">
+                                    <a href="{% url 'property-update' property.id %}">
                                         <button title="Edit Property" class="btn">
                                             {% trans "Edit Property" %}</button>
                                     </a>

--- a/saskatoon/sitebase/templates/app/detail_views/property/contact.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/contact.html
@@ -9,7 +9,7 @@
                 <small>{% trans "(Organization)" %}</small>
             {% elif property.owner_type.is_person and perms.member.change_person %}
                 &nbsp;
-                <small><a href="/person/update/{{property.owner.pk}}/?pid={{property.id}}">
+                <small><a href="{% url 'person-update' property.owner.pk %}?pid={{property.id}}">
                         <i class="fa fa-pencil"></i> {% trans "edit" %}
                 </a></small>
             {% endif %}
@@ -18,7 +18,7 @@
             <h2>{% trans "Unregistered owner" %}
             {% if perms.member.add_person %}
                 &nbsp;
-                <small><a href="/person/create/?pid={{property.id}}">
+                <small><a href="{% url 'person-create' %}?pid={{property.id}}">
                         <i class="fa fa-pencil"></i> {% translate 'register' %}
                 </a></small>
             {% endif %}

--- a/saskatoon/sitebase/templates/app/detail_views/property/harvest_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/harvest_table.html
@@ -9,7 +9,7 @@
                         <h4> {% trans Harvests %}
                             {% if perms.harvest.add_harvest %}
                                 &nbsp;
-                                <a href="/harvest/create/?pid={{ property.id }}">
+                                <a href="{% url 'harvest-create' %}?pid={{ property.id }}">
                                     <button title="New harvest"
                                             class="btn btn-success notika-btn-success waves-effect">
                                         <i class="fa fa-plus"></i>

--- a/saskatoon/sitebase/templates/app/detail_views/property/similar_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/similar_row.html
@@ -14,7 +14,7 @@
     <td>
         {% if perms.member.change_person %}
             {{ property.owner }} &nbsp;
-            <small><a href="/person/update/{{property.owner.pk}}" title="edit">
+            <small><a href="{% url 'person-update' property.owner.pk %}" title="edit">
                 <i class="fa fa-pencil"></i>
             </a></small>
         {% endif %}

--- a/saskatoon/sitebase/templates/app/index/volunteer.html
+++ b/saskatoon/sitebase/templates/app/index/volunteer.html
@@ -21,6 +21,6 @@
 
 <div class="breadcomb-report">
     <div class="text-left mg-t-30">
-        <a href="/calendar" class="btn btn-sm" role="button">{% translate 'Go to calendar' %}</a>
+        <a href="{% url 'calendar' %}" class="btn btn-sm" role="button">{% translate 'Go to calendar' %}</a>
     </div>
 </div>

--- a/saskatoon/sitebase/templates/app/list_views/beneficiary/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/beneficiary/data_row.html
@@ -5,7 +5,7 @@
     <td>
         {% if perms.member.delete_actor %}
             <small>
-                <a href="/admin/member/actor/{{org.actor_id}}/delete"
+                <a href="{% url 'admin:member_actor_delete' org.actor_id %}"
                 onclick="return confirm('{% trans "Are you really sure you want to delete this actor?" %}');">
                     <i class="fa fa-trash text-danger"></i>
                 </a>
@@ -22,7 +22,7 @@
             {% endif %}
             {% if perms.member.change_actor %}
                 &nbsp;
-                <small><a href="/beneficiary/update/{{org.actor_id}}"
+                <small><a href="{% url 'beneficiary-update' org.actor_id %}"
                         title="edit">
                     <i class="fa fa-pencil"></i>
                 </a></small>
@@ -41,7 +41,7 @@
 
         {% if perms.member.change_person %}
             &nbsp;
-            <small><a href="/person/update/{{org.contact_person.actor_id}}"
+            <small><a href="{% url 'person-update' org.contact_person.actor_id %}"
                     title="edit">
                 <i class="fa fa-pencil"></i>
             </a></small>

--- a/saskatoon/sitebase/templates/app/list_views/community/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/community/data_row.html
@@ -6,7 +6,7 @@
         {% if perms.member.delete_actor %}
             &nbsp;
             <small>
-                <a href="/admin/member/actor/{{user.person.actor_id}}/delete"
+                <a href="{% url 'admin:member_actor_delete' user.person.actor_id %}"
                     onclick="return confirm('{% trans "Are you really sure you want to delete this actor?" %}');">
                     <i class="fa fa-trash text-danger"></i>
                 </a>
@@ -16,7 +16,7 @@
     <td>
         <span><b>{{ user.person.name }}</b> &nbsp;
         {% if perms.member.change_person %}
-            <small><a href="/person/update/{{user.person.actor_id}}"
+            <small><a href="{% url 'person-update' user.person.actor_id %}"
                     title="edit">
                 <i class="fa fa-pencil"></i>
             </a></small>
@@ -25,7 +25,7 @@
         <a href='mailto:{{user.email}}'>{{ user.email }}</a> &nbsp;
         {% if perms.member.change_authuser %}
             {% if 'core' in user.role_codes or 'pickleader' in user.role_codes %}
-                <a href="/admin/member/authuser/{{user.id}}/password/"
+                <a href="{% url 'admin:auth_user_password_change' user.id %}"
                 onclick="return confirm('{% trans "Are you sure you want to reset this user password?" %}');"
                 {% if not user.password %}
                     title="register-user"
@@ -73,7 +73,7 @@
     </td>
     <td>
         {% for property in user.person.properties %}
-            <p><a href="/property/{{ property.id }}">{{ property.short_address }}</a></p>
+            <p><a href="{% url 'property-detail' property.id %}">{{ property.short_address }}</a></p>
         {% endfor %}
     </td>
     <td>{{ user.person.neighborhood.name }}</td>

--- a/saskatoon/sitebase/templates/app/list_views/community/harvest_list.html
+++ b/saskatoon/sitebase/templates/app/list_views/community/harvest_list.html
@@ -1,6 +1,6 @@
 
 <li>
-    <a data-placement="top" data-toggle="tooltip" href='/harvest/{{ harvest.id }}'
+    <a data-placement="top" data-toggle="tooltip" href="{% url 'harvest-detail' harvest.id %}"
        title="{{harvest}} lead by {{ harvest.pick_leader.person.name }}">
         {% if harvest.status == "Succeeded" %}
             <i class="fa fa-shopping-basket fa-lg text-success"

--- a/saskatoon/sitebase/templates/app/list_views/community/missed_list.html
+++ b/saskatoon/sitebase/templates/app/list_views/community/missed_list.html
@@ -1,6 +1,6 @@
 
 <li>
-    <a data-placement="top" data-toggle="tooltip" href='/harvest/{{ harvest.id }}'
+    <a data-placement="top" data-toggle="tooltip" href="{% url 'harvest-detail' harvest.id %}"
        title="{{harvest}} lead by {{ harvest.pick_leader.person.name }}">
             <i class="fa fa-shopping-basket fa-lg text-muted"
                title="missed"

--- a/saskatoon/sitebase/templates/app/list_views/community/pending_list.html
+++ b/saskatoon/sitebase/templates/app/list_views/community/pending_list.html
@@ -1,6 +1,6 @@
 
 <li>
-    <a data-placement="top" data-toggle="tooltip" href='/harvest/{{ harvest.id }}'
+    <a data-placement="top" data-toggle="tooltip" href="{% url 'harvest-detail' harvest.id %}"
        title="{{harvest}} lead by {{ harvest.pick_leader.person.name }}">
             <i class="fa fa-shopping-basket fa-lg text-warning"
                title="pending"

--- a/saskatoon/sitebase/templates/app/list_views/equipment/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/equipment/data_row.html
@@ -7,7 +7,7 @@
     <td>
         <span>{{ equipment.description }}
             {% if perms.harvest.change_equipment %}
-            <a href="/equipment/update/{{equipment.id}}">
+            <a href="{% url 'equipment-update' equipment.id %}">
                 &nbsp; <i class="fa fa-pencil"></i></a>
             {% endif %}
         </span><br>
@@ -38,7 +38,7 @@
 
     </td>
     <td>
-        <a href="/property/{{equipment.property.id}}">
+        <a href="{% url 'property-detail' equipment.property.id %}">
         {{ equipment.property.address }}
         </a>
     </td>

--- a/saskatoon/sitebase/templates/app/list_views/harvest/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/harvest/data_row.html
@@ -7,7 +7,7 @@
     {% if perms.harvest.delete_harvest %}
         &nbsp;
         <small>
-            <a href="/admin/harvest/harvest/{{harvest.id}}/delete"
+            <a href="{% url 'admin:harvest_harvest_delete' harvest.id %}"
             onclick="return confirm('{% trans "Are you really sure you want to delete this harvest?" %}');"
                 <i class="fa fa-trash text-danger"></i>
             </a>
@@ -15,7 +15,7 @@
     {% endif %}
     </td>
     <td>
-        <a href='/harvest/{{harvest.id}}'>{{ harvest.property.title }}</a>
+        <a href="{% url 'harvest-detail' harvest.id %}">{{ harvest.property.title }}</a>
     </td>
     <td>
         {% for tree in harvest.trees %}

--- a/saskatoon/sitebase/templates/app/list_views/property/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/property/data_row.html
@@ -8,7 +8,7 @@
     {% if perms.harvest.delete_property %}
     &nbsp;
     <small>
-        <a href="/admin/harvest/property/{{property.id}}/delete"
+        <a href="{% url 'admin:harvest_property_delete' property.id %}"
            onclick="return confirm('{% trans "Are you really sure you want to delete this property?" %}');">
             <i class="fa fa-trash text-danger"></i>
         </a>
@@ -16,7 +16,7 @@
     {% endif %}
     </td>
     <td>
-        <a href='/property/{{property.id}}'>{{ property.title }}</a>
+        <a href="{% url 'property-detail' property.id %}">{{ property.title }}</a>
     </td>
     <td>{{ property.neighborhood.name }}</td>
     <td>
@@ -31,7 +31,7 @@
         <ul class="list-inline">
             {% for harvest in property.harvests %}
             <li>
-                <a data-placement="top" data-toggle="tooltip" href='/harvest/harvest.id'
+                <a data-placement="top" data-toggle="tooltip" href="{% url 'harvest-detail' harvest.id %}"
                     title="Harvest #{{ harvest.id }} in {{ harvest.start_date }} by {{ harvest.pick_leader__person__first_name }}">
                     {% if harvest.status == "Succeeded" %}
                     <i class="fa fa-shopping-basket fa-lg text-success"

--- a/saskatoon/sitebase/templates/app/participation_list.html
+++ b/saskatoon/sitebase/templates/app/participation_list.html
@@ -28,7 +28,7 @@
                                 <td>{{ equipment.id }}</td>
                                 <td>{{ equipment.type.name }}</td>
                                 <td>
-                                    <a href='/equipment/{{equipment.id}}'>{{ equipment.description }}</a>
+                                    <a href='{% url 'equipment-detail' equipment.id %}'>{{ equipment.description }}</a>
                                 </td>
                                 <td>{{ equipment.property.title }}</td>
                                 <td>{{ equipment.property.neighborhood.name }}</td>

--- a/saskatoon/sitebase/templates/registration/login.html
+++ b/saskatoon/sitebase/templates/registration/login.html
@@ -106,7 +106,7 @@
 
                 <div class="nk-navigation nk-lg-ic">
                     <!-- <a href="#" data-ma-action="nk-login-switch" data-ma-block="#l-register"><i class="notika-icon notika-plus-symbol"></i> <span>{% trans 'Register' %}</span></a> -->
-                    <a href="/reset_password/" data-ma-action="nk-login-switch" data-ma-block="#l-forget-password"><i>?</i> <span>{% trans "Forgot Password" %}</span></a>
+                    <a href="{% url 'reset_password' %}" data-ma-action="nk-login-switch" data-ma-block="#l-forget-password"><i>?</i> <span>{% trans "Forgot Password" %}</span></a>
                 </div>
         </form>
     </div>


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->
Fixes #274 
----------
## Type of change:
- [x] Refactor.
----------
## What's Changed:
- Reversed urls in multiple templates for portability and robustness when changing urls.
--------
## Affected URLs:
- `127.0.0.1:8000/`
- `127.0.0.1:8000/harvest/<pk>`
- `127.0.0.1:8000/property/<pk>`
- `127.0.0.1:8000/harvest/`
- `127.0.0.1:8000/property/`
- `127.0.0.1:8000/equipment/`
- `127.0.0.1:8000/community/`

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
