### PR TITLE
Fix 266 Add authorized=null option in PropertyFilter

### DIFF
--- a/saskatoon/harvest/filters.py
+++ b/saskatoon/harvest/filters.py
@@ -14,6 +14,16 @@ SEASON_FILTER_RANGE = (2016, datetime.now().year)
 
 class HarvestFilter(filters.FilterSet):
 
+    class Meta:
+        model = Harvest
+        fields = [
+            'status',
+            'pick_leader',
+            'trees',
+            'property__neighborhood',
+            'season',
+        ]
+
     YEARS = list(range(SEASON_FILTER_RANGE[0], SEASON_FILTER_RANGE[1]+1))
 
     season = filters.ChoiceFilter(
@@ -51,35 +61,8 @@ class HarvestFilter(filters.FilterSet):
         required=False
     )
 
-    class Meta:
-        model = Harvest
-        fields = (
-            'status',
-            'pick_leader',
-            'trees',
-            'property__neighborhood',
-            'season',
-        )
-
 
 class PropertyFilter(filters.FilterSet):
-    is_active = filters.BooleanFilter(help_text="")
-    authorized = filters.BooleanFilter(help_text="")
-    neighborhood = filters.ModelChoiceFilter(
-        queryset=Neighborhood.objects.all(),
-        label=_("Neighborhood"),
-        help_text="",
-        required=False
-    )
-    trees = filters.ModelChoiceFilter(
-        queryset=TreeType.objects.all(),
-        label=_("Tree"),
-        help_text="",
-        required=False
-    )
-    ladder_available = filters.BooleanFilter(help_text="")
-    ladder_available_for_outside_picks = filters.BooleanFilter(help_text="")
-    pending = filters.BooleanFilter(help_text="", label=_("Pending validation"))
 
     class Meta:
         model = Property
@@ -91,10 +74,68 @@ class PropertyFilter(filters.FilterSet):
             'ladder_available',
             'ladder_available_for_outside_picks',
             'pending',
-            ]
+        ]
+
+    is_active = filters.BooleanFilter(
+        label=_("Active"),
+        help_text=""
+    )
+
+    authorized = filters.ChoiceFilter(
+        choices=[
+            (2, _("Not yet authorized")),
+            (1, _("Authorized")),
+            (0, _("Unauthorized"))
+        ],
+        label=_("Authorized"),
+        help_text="",
+        method='authorized_filter'
+    )
+
+    neighborhood = filters.ModelChoiceFilter(
+        queryset=Neighborhood.objects.all(),
+        label=_("Neighborhood"),
+        help_text="",
+        required=False
+    )
+
+    trees = filters.ModelChoiceFilter(
+        queryset=TreeType.objects.all(),
+        label=_("Tree"),
+        help_text="",
+        required=False
+    )
+
+    ladder_available = filters.BooleanFilter(
+        help_text=""
+    )
+
+    ladder_available_for_outside_picks = filters.BooleanFilter(
+        help_text=""
+    )
+
+    pending = filters.BooleanFilter(
+        help_text="",
+        label=_("Pending validation")
+    )
+
+    def authorized_filter(self, queryset, name, choice):
+        if choice == '2':
+            return queryset.filter(authorized__isnull=True)
+        return queryset.filter(authorized=bool(int(choice)))
 
 
 class CommunityFilter(filters.FilterSet):
+
+    class Meta:
+        model = AuthUser
+        fields = [
+            'groups',
+            'person__first_name',
+            'person__family_name',
+            'person__neighborhood',
+            'person__language',
+        ]
 
     groups = filters.ModelChoiceFilter(
         queryset=Group.objects.all(),
@@ -135,19 +176,14 @@ class CommunityFilter(filters.FilterSet):
         query = (Q(person__family_name__icontains=value))
         return queryset.filter(query)
 
-    class Meta:
-        model = AuthUser
-        fields = [
-            'groups',
-            'person__first_name',
-            'person__family_name',
-            'person__neighborhood',
-            'person__language',
-        ]
-
 
 # FIXME: won't filter
 class OrganizationFilter(filters.FilterSet):
+
+    class Meta:
+        model = Organization
+        fields = ['neighborhood', 'is_beneficiary']
+
     neighborhood = filters.ModelChoiceFilter(
         queryset=Neighborhood.objects.all(),
         label=_("Neighborhood"),
@@ -155,22 +191,24 @@ class OrganizationFilter(filters.FilterSet):
         required=False
     )
 
-    class Meta:
-        model = Organization
-        fields = ['neighborhood', 'is_beneficiary']
 
 
 class EquipmentFilter(filters.FilterSet):
-    shared = filters.BooleanFilter(help_text="")
+
+    class Meta:
+        model = Equipment
+        fields = ['type', 'shared']
+
+    shared = filters.BooleanFilter(
+        help_text=""
+    )
+
     type = filters.ModelChoiceFilter(
         queryset=EquipmentType.objects.all(),
         label=_("Type"),
         help_text="",
         required=False
     )
-    class Meta:
-        model = Equipment
-        fields = ['type', 'shared']
 
 
 # # ADMIN filters # #
@@ -210,7 +248,6 @@ class PropertyHasHarvestAdminFilter(SimpleListFilter):
 
     def queryset(self, request, queryset):
         if self.value():
-            test = bool(int(self.value()))
-            print("test", test)
-            return queryset.filter(harvests__isnull=test)
+            is_null = bool(int(self.value()))
+            return queryset.filter(harvests__isnull=is_null)
         return queryset

--- a/saskatoon/harvest/filters.py
+++ b/saskatoon/harvest/filters.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from django.contrib.admin import SimpleListFilter
 from django.contrib.auth.models import Group
 from django.db.models.query_utils import Q
@@ -8,7 +9,7 @@ from harvest.models import (Harvest, HARVESTS_STATUS_CHOICES, TreeType,
 from member.models import Language, AuthUser, Neighborhood, Organization
 
 
-SEASON_FILTER_RANGE = (2016, 2022)
+SEASON_FILTER_RANGE = (2016, datetime.now().year)
 
 
 class HarvestFilter(filters.FilterSet):

--- a/saskatoon/harvest/models.py
+++ b/saskatoon/harvest/models.py
@@ -9,6 +9,7 @@ import datetime
 from djgeojson.fields import PointField
 from phone_field import PhoneField
 
+
 HARVESTS_STATUS_CHOICES = (
     (
         "To-be-confirmed",
@@ -39,6 +40,8 @@ HARVESTS_STATUS_CHOICES = (
         _("Cancelled"),
     )
 )
+
+
 class TreeType(models.Model):
     name = models.CharField(
         verbose_name=_("Name"),

--- a/saskatoon/sitebase/templates/app/list_views/filters.html
+++ b/saskatoon/sitebase/templates/app/list_views/filters.html
@@ -18,7 +18,6 @@
             <div class="collapse" id="accordionGreen-one" role="tabpanel">
                 <div class="panel-body" style="display:inline-block;">
                     <form role="form">
-                        {% csrf_token %}
                         {{ filter.form|crispy }}
                         <div class="form-group"
                              style="margin-top:2rem;">


### PR DESCRIPTION
Fixes #266
----------
## Type of change:
- Bug fix (change which fixes an issue).
----------
## What's Changed:
- changed `authorized` BooleanFilter into ChoiceFilter in PropertyFilter to allow filtering by all three options: null / true / false
- current year is no longer hardcoded in HarvestFilter
- general cleanup in filters
- removed CRSF token in all filter forms (GET request)
----------
## Affected urls:
- localhost:8000/property/?authorized=2
- localhost:8000/property/?authorized=1
- localhost:8000/property/?authorized=0
-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
