### PR TITLE
Fix broken reversed urls & not taking orphaned harvests into account

### DIFF
--- a/saskatoon/sitebase/templates/app/detail_views/property/harvest_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/harvest_row.html
@@ -12,7 +12,7 @@
         {% if perms.harvest.delete_harvest %}
             &nbsp;
             <small>
-                <a href="{% url 'harvest_delete' harvest.id %}"
+                <a href="{% url 'admin:harvest_harvest_delete' harvest.id %}"
                 onclick="return confirm('{% trans "Are you really sure you want to delete this harvest?" %}');"
                     <i class="fa fa-trash text-danger"></i>
                 </a>

--- a/saskatoon/sitebase/templates/app/detail_views/property/harvest_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/harvest_row.html
@@ -2,7 +2,13 @@
 {% load static %}
 <tr>
     <td>
-        <a href='{% url "harvest-detail" harvest.id %}'>#{{ harvest.id }} Harvest by {{ harvest.pick_leader.name }}</a>
+        <a href='{% url "harvest-detail" harvest.id %}'>
+            {% if harvest.pick_leader %}
+                #{{ harvest.id }} Harvest by {{ harvest.pick_leader.name }}
+            {% else %}
+                #{{ harvest.id }} Orphaned Harvest
+            {% endif %}
+        </a>
         {% if perms.harvest.delete_harvest %}
             &nbsp;
             <small>
@@ -14,23 +20,27 @@
         {% endif %}
     </td>
     <td>
-        <b>{{ harvest.pick_leader.name }}</b>
-
-        {% if perms.member.change_person %}
+        {% if harvest.pick_leader %}
+            <b>{{ harvest.pick_leader.name }}</b>
+            {% if perms.member.change_person %}
             &nbsp;
             <small><a href="{% url 'person-update' harvest.pick_leader.actor_id %}"
-                    title="edit">
+                title="edit">
                 <i class="fa fa-pencil"></i>
             </a></small>
-        {% endif %}
-        {% if harvest.pick_leader.phone %}
+            {% endif %}
+
+            {% if harvest.pick_leader.phone %}
             <br> <i class="fa fa-mobile text-muted"></i>&nbsp;
             {{ harvest.pick_leader.phone }}
+            {% endif %}
+            <br>
+            <a href="mailto:{{harvest.pick_leader.email}}">
+                {{ harvest.pick_leader.email }}
+            </a>
+        {% else %}
+            <b>Orphaned</b>
         {% endif %}
-        <br>
-        <a href="mailto:{{harvest.pick_leader.email}}">
-            {{ harvest.pick_leader.email }}
-        </a>
     </td>
     <td>
         {% if harvest.status == "Succeeded" %}


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->
Fixes https://github.com/LesFruitsDefendus/saskatoon-ng/pull/239#issuecomment-1144996441
----------
## Type of change:
- [x] Bug fix (change which fixes an issue).

----------
## What's Changed:
- fixed a wrongly reversed url.
- Orphaned harvests aren't taken into account by some elements in the template.

--------
## Screenshots:
1. 
![image](https://user-images.githubusercontent.com/52796958/171911271-d5aaf2d0-cb1f-49e9-b51f-bf488795e729.png)
2. 
![image](https://user-images.githubusercontent.com/52796958/171911469-a27ad831-382b-4a90-b344-c0bf992f06b1.png)


--------
## Affected URLs:
e.g. `localhost:8000/property/<pk>`

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.