### PR TITLE
Change some PersonSerializer fields that return querysets

### DIFF
--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -19,14 +19,23 @@ class NeighborhoodSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class PersonHarvestSerializer(serializers.ModelSerializer):
+    pick_leader = serializers.StringRelatedField(many=False, read_only=True)
+    property = serializers.StringRelatedField(many=False, read_only=True)
+
+    class Meta:
+        model = Harvest
+        fields = ['id', 'pick_leader', 'property']
+
+
 class PersonSerializer(serializers.ModelSerializer):
     neighborhood = NeighborhoodSerializer(many=False, read_only=True)
     properties = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-    harvests_as_pickleader = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-    harvests_as_volunteer_accepted = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-    harvests_as_volunteer_pending = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-    harvests_as_volunteer_missed = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
-    harvests_as_owner = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    harvests_as_pickleader = PersonHarvestSerializer(many=True, read_only=True)
+    harvests_as_volunteer_accepted = PersonHarvestSerializer(many=True, read_only=True)
+    harvests_as_volunteer_pending = PersonHarvestSerializer(many=True, read_only=True)
+    harvests_as_volunteer_missed = PersonHarvestSerializer(many=True, read_only=True)
+    harvests_as_owner = PersonHarvestSerializer(many=True, read_only=True)
     organizations_as_contact = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
 
     class Meta:

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -19,6 +19,12 @@ class NeighborhoodSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class PersonPropertySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Property
+        fields = ['id', 'short_address']
+
+
 class PersonHarvestSerializer(serializers.ModelSerializer):
     pick_leader = serializers.StringRelatedField(many=False, read_only=True)
     property = serializers.StringRelatedField(many=False, read_only=True)
@@ -30,7 +36,7 @@ class PersonHarvestSerializer(serializers.ModelSerializer):
 
 class PersonSerializer(serializers.ModelSerializer):
     neighborhood = NeighborhoodSerializer(many=False, read_only=True)
-    properties = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    properties = PersonPropertySerializer(many=True, read_only=True)
     harvests_as_pickleader = PersonHarvestSerializer(many=True, read_only=True)
     harvests_as_volunteer_accepted = PersonHarvestSerializer(many=True, read_only=True)
     harvests_as_volunteer_pending = PersonHarvestSerializer(many=True, read_only=True)

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -34,6 +34,12 @@ class PersonHarvestSerializer(serializers.ModelSerializer):
         fields = ['id', 'pick_leader', 'property']
 
 
+class PersonBeneficiarySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Organization
+        fields = ['pk', 'civil_name']
+
+
 class PersonSerializer(serializers.ModelSerializer):
     neighborhood = NeighborhoodSerializer(many=False, read_only=True)
     properties = PersonPropertySerializer(many=True, read_only=True)
@@ -42,7 +48,7 @@ class PersonSerializer(serializers.ModelSerializer):
     harvests_as_volunteer_pending = PersonHarvestSerializer(many=True, read_only=True)
     harvests_as_volunteer_missed = PersonHarvestSerializer(many=True, read_only=True)
     harvests_as_owner = PersonHarvestSerializer(many=True, read_only=True)
-    organizations_as_contact = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    organizations_as_contact = PersonBeneficiarySerializer(many=True, read_only=True)
 
     class Meta:
         model = Person

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -1,9 +1,8 @@
-import json
 from django.core.serializers import serialize
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from member.models import (Actor, Neighborhood, AuthUser, Person, Organization,
-                           City, State, Country, Language)
+                           City, State, Country)
 from harvest.models import (Harvest, Property, Equipment, EquipmentType,
                             RequestForParticipation, TreeType)
 
@@ -22,6 +21,13 @@ class NeighborhoodSerializer(serializers.ModelSerializer):
 
 class PersonSerializer(serializers.ModelSerializer):
     neighborhood = NeighborhoodSerializer(many=False, read_only=True)
+    properties = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    harvests_as_pickleader = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    harvests_as_volunteer_accepted = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    harvests_as_volunteer_pending = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    harvests_as_volunteer_missed = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    harvests_as_owner = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    organizations_as_contact = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
 
     class Meta:
         model = Person

--- a/saskatoon/sitebase/templates/app/list_views/community/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/community/data_row.html
@@ -75,7 +75,7 @@
             <p><a href="{% url 'property-detail' property.id %}">{{ property.short_address }}</a></p>
         {% endfor %}
         {% for org in user.person.organizations_as_contact %}
-            <a href="{% url 'beneficiary-update' org.pk %}">{{ org }}</a>
+            <a href="{% url 'beneficiary-update' org.pk %}">{{ org.civil_name }}</a>
         {% endfor %}
     </td>
     <td>{{ user.person.neighborhood.name }}</td>

--- a/saskatoon/sitebase/templates/app/list_views/community/harvest_list.html
+++ b/saskatoon/sitebase/templates/app/list_views/community/harvest_list.html
@@ -1,7 +1,7 @@
 
 <li>
     <a data-placement="top" data-toggle="tooltip" href="{% url 'harvest-detail' harvest.id %}"
-       title="{{harvest}} lead by {{ harvest.pick_leader.person.name }}">
+       title="Harvest for {{harvest.property}} lead by {{ harvest.pick_leader }}">
         {% if harvest.status == "Succeeded" %}
             <i class="fa fa-shopping-basket fa-lg text-success"
                title="succeeded"


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->
Fixes #308
----------
## Type of change:
- [x] Bug fix (change which fixes an issue).
----------
## What's Changed:
- Changed the following fields in `PersonSerializer` that return querysets into `PrimaryKeyRelatedField`:
    - harvests_as_pickleader
    - harvests_as_volunteer_accepted
    - harvests_as_volunteer_pending
    - harvests_as_volunteer_missed
    - harvests_as_owner
    - organizations_as_contact
    - properties

--------
## Affected URLs:
- `127.0.0.1:8000/harvest.json`
- `127.0.0.1:8000/harvest/1.json`
- `127.0.0.1:8000/property.json`
- `127.0.0.1:8000/property/3.json`
- `127.0.0.1:8000/beneficiary.json`
- `127.0.0.1:8000/community.json`
- `127.0.0.1:8000/equipment.json`

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
