### PR TITLE
Add drf-yasg/swagger support

### DIFF
--- a/saskatoon/saskatoon/settings.py
+++ b/saskatoon/saskatoon/settings.py
@@ -75,7 +75,8 @@ INSTALLED_APPS = [
     'debug_toolbar',
     'django_extensions',
     'rosetta',
-    'phone_field'
+    'phone_field',
+    'drf_yasg',
 ]
 
 MIDDLEWARE = [

--- a/saskatoon/saskatoon/urls.py
+++ b/saskatoon/saskatoon/urls.py
@@ -1,18 +1,36 @@
-from django.contrib import admin
-from django.urls import path, include
 import debug_toolbar
 from django.conf import settings
+from django.contrib import admin
+from django.urls import include, path, re_path
+from drf_yasg import openapi
+from drf_yasg.views import get_schema_view
+from rest_framework import permissions
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Snippets API",
+        default_version='v1',
+        description="Test description",
+        terms_of_service="https://www.google.com/policies/terms/",
+        contact=openapi.Contact(email="contact@snippets.local"),
+        license=openapi.License(name="BSD License"),
+    ),
+    public=True,
+    permission_classes=[permissions.AllowAny],
+)
 
 urlpatterns = [
     path('', include('sitebase.urls')),
     path('', include('member.urls')),
     path('', include('harvest.urls')),
-    path('',include('django.contrib.auth.urls')),
+    path('', include('django.contrib.auth.urls')),
     path('admin/', admin.site.urls),
     path('accounts/', include('django.contrib.auth.urls')),
     path('i18n/', include('django.conf.urls.i18n')),
     path('__debug__/', include(debug_toolbar.urls)),
-    path('rosetta/', include('rosetta.urls'))
+    path('rosetta/', include('rosetta.urls')),
+    re_path(r'^swagger/$', schema_view.with_ui('swagger',
+            cache_timeout=0), name='schema-swagger-ui'),
 ]
 
 handler400 = 'sitebase.views.handler400'

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,9 @@ setup(
         "django-crispy-forms",
         "django-rosetta==0.9.8",
         "django-phone-field==1.8.1",
-        "postalcodes-ca==0.0.9"
+        "postalcodes-ca==0.0.9",
+        "drf-yasg==1.20.0",
+        "swagger-spec-validator>=2.1.0",
     ],
     extras_require      =   {
         'test': ['pytest', 'selenium', 'pytest-django', 'invoke', 'tox']


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->
Fixes #307 
----------
## Type of change:
- [x] New feature (change which adds functionality).
----------
## What's Changed:
- Added swagger-ui support, exposed a url & added [drf-yasg](https://github.com/axnsan12/drf-yasg) dependencies to `setup.py` 

--------
## Screenshots:
1. 
![image](https://user-images.githubusercontent.com/52796958/173114224-c8eb2fb1-f546-4423-84a4-9c9a21c15e2a.png)


--------
## Affected URLs:
e.g. `127.0.0.1:8000/swagger/`

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
