### PR TITLE
Fix 311 - PersonUpdateForm email validation and auth_user creation

### DIFF
--- a/saskatoon/member/validators.py
+++ b/saskatoon/member/validators.py
@@ -1,0 +1,20 @@
+# coding: utf-8
+from django.forms import ValidationError
+from django.utils.translation import gettext_lazy as _
+from member.models import AuthUser
+
+
+def validate_email(email, auth_user=None):
+    '''Check if a user with same email address is already registered'''
+
+    if auth_user and not email:
+        raise ValidationError(_("ERROR: New email address cannot be empty."))
+
+    duplicates = AuthUser.objects.filter(email=email)
+    if auth_user:
+        duplicates = duplicates.exclude(id=auth_user.id)
+
+    if duplicates.exists():
+        raise ValidationError(
+            _("ERROR: email address < {} > is already registered!").format(email)
+        )


### PR DESCRIPTION
Fixes #311
----------
## Type of change:
- [x] Bug fix (change which fixes an issue).
- [x] New feature (change which adds functionality).
- [ ] Changes to models (requires making migrations).
- [ ] Documentation change.
----------
## What's Changed:
PersonUpdateForm

- if Person has no AuthUser and email+roles fields are left empty, save as is
- if Person has no AuthUser and email+roles fields are filled, create a new user
- if Person has AuthUser and email does not change, do not raise validation error
- if Person has AuthUser and email or roles are empty, raise validation Error

--------
## Screenshots:
1. one screenshot.
2. another.

--------
## Affected URLs:
http://localhost:8000/person/update/<id>/

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
