### PR TITLE
Add "do not reply" Note to Emails

### DIFF
--- a/saskatoon/harvest/signals.py
+++ b/saskatoon/harvest/signals.py
@@ -23,6 +23,7 @@ def clear_cache_people(sender, instance, **kwargs):
 
 def _send_mail(subject, message, mail_to):
     subject = '[Sakatoon] ' + subject
+    message = "{}\n\nThis email is auto-generated. Please do not reply to it.".format(message)
     send_mail(
             subject,
             message,


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->
Fixes #302 
----------
## Type of change:
- [x] Enhancement
----------
## What's Changed:
- Added a note at the end of emails telling members not to reply to emails.
--------
## Screenshots:
1. 
![image](https://user-images.githubusercontent.com/52796958/174348582-a1948f34-36dc-405c-96b3-ccb9312fc357.png)


--------
## Affected URLs:
http://127.0.0.1:8000/comment/create/?h=2

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
