### PR TITLE
Fix 315 Make publish_date optional and simplify is_publishable

### DIFF
--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -518,6 +518,7 @@ class HarvestForm(forms.ModelForm):
             'pick_leader',
             'start_date',
             'end_date',
+            'publication_date',
             'nb_required_pickers',
             'about',
         )
@@ -543,21 +544,24 @@ class HarvestForm(forms.ModelForm):
         required=True
     )
 
-    publication_date = forms.DateTimeField(
-        widget=forms.HiddenInput(),
-        required=False
-    )
-
     start_date = forms.DateTimeField(
-        input_formats=['%d/%m/%Y %H:%M', '%d/%m/%Y %H:%M:%S']
+        input_formats=['%d/%m/%Y %H:%M', '%d/%m/%Y %H:%M:%S'],
+        required=True
     )
     end_date = forms.DateTimeField(
-        input_formats=['%d/%m/%Y %H:%M', '%d/%m/%Y %H:%M:%S']
+        input_formats=['%d/%m/%Y %H:%M', '%d/%m/%Y %H:%M:%S'],
+        required=True
+    )
+
+    publication_date = forms.DateTimeField(
+        input_formats=['%d/%m/%Y %H:%M', '%d/%m/%Y %H:%M:%S'],
+        label=_("Publication date (OPTIONAL)"),
+        help_text=_("Leave this field empty to publish harvest as soon as possible"),
+        required=False
     )
 
     def clean_pick_leader(self):
         """check if pick-leader was selected"""
-
         pickleader = self.cleaned_data['pick_leader']
         status = self.cleaned_data['status']
         if not pickleader and status not in ["To-be-confirmed", "Orphan"]:
@@ -565,18 +569,6 @@ class HarvestForm(forms.ModelForm):
                 _("You must choose a pick leader or change harvest status")
             )
         return pickleader
-
-    def clean_publication_date(self):
-        """Manage hidden input"""
-
-        date = self.cleaned_data['publication_date']
-        status = self.cleaned_data['status']
-
-        if status in ["Ready", "Date-scheduled", "Succeeded"]:
-            date = dt.now() if date is None else date
-        elif status in ["To-be-confirmed", "Orphan", "Adopted"]:
-            date = None
-        return date
 
 
 class HarvestYieldForm(forms.ModelForm):

--- a/saskatoon/member/admin.py
+++ b/saskatoon/member/admin.py
@@ -79,7 +79,7 @@ class AuthUserAdmin(UserAdmin):
     form = CustomUserChangeForm
     add_form = CustomUserCreationForm
     search_fields = ('email', 'person__first_name', 'person__family_name')
-    ordering = ('email', 'person')
+    ordering = ('email', 'person', 'date_joined', 'last_login')
     filter_horizontal = ('groups', 'user_permissions',)
     list_display = ('email',
                     'person',
@@ -88,7 +88,10 @@ class AuthUserAdmin(UserAdmin):
                     'is_core',
                     'is_admin',
                     'is_active',
-                    'id'
+                    'id',
+                    'date_joined',
+                    'has_password',
+                    'last_login',
                     )
 
     @admin.display(boolean=True, description="Core")
@@ -102,6 +105,10 @@ class AuthUserAdmin(UserAdmin):
     @admin.display(description="Group(s)")
     def get_groups(self, user):
         return ' + '.join([g.name for g in user.groups.all()])
+
+    @admin.display(boolean=True, description="Password")
+    def has_password(self, user):
+        return user.password != ''
 
     list_filter = (UserGroupAdminFilter,
                    UserHasPropertyAdminFilter,

--- a/saskatoon/sitebase/templates/app/base/scripts.html
+++ b/saskatoon/sitebase/templates/app/base/scripts.html
@@ -99,6 +99,10 @@
          format: 'd/m/Y H:i',
      });
 
+     $("#id_publication_date").datetimepicker({
+         format: 'd/m/Y H:i',
+     });
+
      $("#id_approximative_maturity_date").datetimepicker({
          format: 'Y-m-d',
      });


### PR DESCRIPTION
Fixes #315

**Urgent, targeting master**
----------
## Type of change:
- [x] Bug fix (change which fixes an issue).
- [ ] New feature (change which adds functionality).
- [ ] Changes to models (requires making migrations).
- [ ] Documentation change.
----------
## What's Changed:
- `publication_date` now appears has an optional field in Harvest Form
- if it is left empty (`publication_date=None`), then `is_publishable` simply checks for the harvest status
- if it is set, then we take it into account in `is_publishable` as done before
- Calendar used to compare dates and not datetimes, meaning harvest could still be opened the day of and I believe the ("calendar updates at 18h" (0:00 UTC) limitation was also related to this, which is unecessary.
- Requests are now open until 2 HOURS prior to harvests, we should tweak this number based on core members' needs

--------
## Affected URLs:
http://localhost:8000/harvest/update/<id>

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x]] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
