### PR TITLE
Hotfix - add default filters to menu links to try and reduce loading time

### DIFF
--- a/saskatoon/sitebase/templates/app/base/menu.html
+++ b/saskatoon/sitebase/templates/app/base/menu.html
@@ -13,16 +13,19 @@
                                 <a href="{% url 'calendar' %}">{% translate "Calendar" %} </a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'harvest-list' %}active{% endif %}">
-                                <a href="{% url 'harvest-list' %}">{% translate "Harvests" %} </a>
+                                <!--TODO <a href="{% url 'harvest-list' %}">{% translate "Harvests" %} </a> -->
+                                <a href="{% url 'harvest-list' %}?season=2022">{% translate "Harvests" %} </a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'property-list' %}active{% endif %}">
-                                <a href="{% url 'property-list' %}">{% translate "Properties" %}</a>
+                                <!--TODO <a href="{% url 'community-list' %}">{% translate "Community" %}</a> -->
+                                <a href="{% url 'property-list' %}?is_active=true">{% translate "Properties" %}</a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'beneficiary-list' %}active{% endif %}">
                                 <a href="{% url 'beneficiary-list' %}">{% translate "Beneficiaries" %}</a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'community-list' %}active{% endif %}">
-                                <a href="{% url 'community-list' %}">{% translate "Community" %}</a>
+                                <!--TODO <a href="{% url 'community-list' %}">{% translate "Community" %}</a> -->
+                                <a href="{% url 'community-list' %}?groups=3">{% translate "Community" %}</a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'equipment-list' %}active{% endif %}">
                                 <a href="{% url 'equipment-list' %}">{% translate "Equipment" %}</a>
@@ -48,16 +51,19 @@
                         <a href="{% url 'calendar' %}"><i class="fa fa-table"></i> {% translate "Calendar" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'harvest-list' %}active{% endif %}">
-                        <a href="{% url 'harvest-list' %}"><i class="fa fa-shopping-basket"></i> {% translate "Harvests" %}</a>
+                        <!--TODO <a href="{% url 'harvest-list' %}"><i class="fa fa-shopping-basket"></i> {% translate "Harvests" %}</a> -->
+                        <a href="{% url 'harvest-list' %}?season=2022"><i class="fa fa-shopping-basket"></i> {% translate "Harvests" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'property-list' %}active{% endif %}">
-                        <a href="{% url 'property-list' %}"><i class="glyphicon glyphicon-tree-deciduous"></i> {% translate "Properties" %}</a>
+                        <!--TODO <a href="{% url 'property-list' %}"><i class="glyphicon glyphicon-tree-deciduous"></i> {% translate "Properties" %}</a> -->
+                        <a href="{% url 'property-list' %}?is_active=true"><i class="glyphicon glyphicon-tree-deciduous"></i> {% translate "Properties" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'beneficiary-list' %}active{% endif %}">
                         <a href="{% url 'beneficiary-list' %}"><i class="fa fa-gift"></i> {% translate "Beneficiaries" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'community-list' %}active{% endif %}">
-                        <a href="{% url 'community-list' %}"><i class="fa fa-users"></i> {% translate "Community" %}</a>
+                        <!--TODO <a href="{% url 'community-list' %}"><i class="fa fa-users"></i> {% translate "Community" %}</a> -->
+                        <a href="{% url 'community-list' %}?groups=3"><i class="fa fa-users"></i> {% translate "Community" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'equipment-list' %}active{% endif %}">
                         <a href="{% url 'equipment-list' %}"><i class="fa fa-scissors"></i> {% translate "Equipment" %}</a>


### PR DESCRIPTION

## What's Changed:
Hardcoded default filters when clicking on Menu links to try and reduce loading time:
- Harvest list -> 2022 season
- Community list -> pickleader role
- Property list -> active = true

## Affected URLs:
- harvest/
- community/
- property/


-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
