### PR TITLE
HotFix guides links

### DIFF
--- a/saskatoon/sitebase/templates/app/index/pickleader.html
+++ b/saskatoon/sitebase/templates/app/index/pickleader.html
@@ -10,17 +10,17 @@
     {% trans "Map: Equipment Points, Beneficiary Organizations & Community Fridges" as map %}
 
     <ul class="list-group" style="list-style-type: square">
-        <li><a href="https://core.lesfruitsdefendus.org/s/kGdMRpLDB6pKbMi">{{waiver}}</a></li>
+        <li><a href="">FIXME {{waiver}}</a></li>
         {% if LANGUAGE_CODE == "en" %}
-            <li><a href="https://core.lesfruitsdefendus.org/s/EzxazYFo9yKknzf">{{prepick}}</a></li>
-            <li><a href="https://core.lesfruitsdefendus.org/s/XF9BsA2E3XtSt4k">{{annexB}}</a></li>
-            <li><a href="https://core.lesfruitsdefendus.org/s/tfBdJpT7XwdwqNk">{{annexD}}</a></li>
-            <li><a href="https://core.lesfruitsdefendus.org/s/cJQPc82H7C9zzNB">{{harvest}}</a></li>
+            <li><a href="https://lesfruitsdefendus.readthedocs.io/en/latest/pre-pick-guide/index.html">{{prepick}}</a></li>
+            <li><a href="">FIXME {{annexB}}</a></li>
+            <li><a href="https://lesfruitsdefendus.readthedocs.io/en/latest/pre-pick-guide/annexes/D-using-the-property-list.html">{{annexD}}</a></li>
+            <li><a href="https://lesfruitsdefendus.readthedocs.io/en/latest/harvest-guide/index.html">{{harvest}}</a></li>
         {% else %}
-            <li><a href="https://core.lesfruitsdefendus.org/s/WGLxswS9tx7jDkE">{{prepick}}</a></li>
-            <li><a href="https://core.lesfruitsdefendus.org/s/4AqHtTn4K9oCeDY">{{annexB}}</a></li>
-            <li><a href="https://core.lesfruitsdefendus.org/s/g9kMGsnr8g2e857">{{annexD}}</a></li>
-            <li><a href="https://core.lesfruitsdefendus.org/s/JA2sP6dQgkdkLNH">{{harvest}}</a></li>
+            <li><a href="https://lesfruitsdefendus.readthedocs.io/fr/latest/pre-pick-guide/index.html">{{prepick}}</a></li>
+            <li><a href="">FIXME {{annexB}}</a></li>
+            <li><a href="https://lesfruitsdefendus.readthedocs.io/fr/latest/pre-pick-guide/annexes/D-using-the-property-list.html">{{annexD}}</a></li>
+            <li><a href="https://lesfruitsdefendus.readthedocs.io/fr/latest/harvest-guide/index.html">{{harvest}}</a></li>
         {% endif %}
         <li> <a href="https://drive.google.com/open?id=1VJbxaFKosG7gLgfvYJZ9m6rhTg0M3ZDy&usp=sharing">{{map}}</a> </li>
     </ul>


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->
Fixes #319 
----------
## Type of change:
- [x] Bug fix (change which fixes an issue).
- [ ] New feature (change which adds functionality).
- [ ] Changes to models (requires making migrations).
- [x] Documentation change.
----------
## What's Changed:
- Fix the links to the guides publicly available
- Put place holder in place of the annex B and Waiver form, these PDFs should be hosted by saskatoon and downloadable only for core members and pickleaders.
- I don't think we have proper translation fort annex B nor the waiver form, it's only in french and english, respectively. So there are only two PDFs to host in total.

--------
## Affected URLs:
e.g. `127.0.0.1:8000/index.html`

-------
## Checklist:
- [ ] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
