### PR TITLE
Refactor harvest list view

### DIFF
--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -13,7 +13,7 @@ from member.models import AuthUser, Organization, Neighborhood, Person
 from harvest.models import (Equipment, Harvest, HarvestYield, Property,
                             RequestForParticipation, Comment, TreeType)
 from harvest.permissions import IsCoreOrAdmin
-from harvest.serializers import (HarvestSerializer, PropertySerializer, EquipmentSerializer,
+from harvest.serializers import (HarvestListSerializer, HarvestSerializer, PropertySerializer, EquipmentSerializer,
                                  CommunitySerializer, BeneficiarySerializer,
                                  RequestForParticipationSerializer)
 from harvest.utils import get_similar_properties
@@ -83,6 +83,7 @@ class HarvestViewset(LoginRequiredMixin, viewsets.ModelViewSet):
 
     def list(self, request, *args, **kwargs):
         self.template_name = 'app/list_views/harvest/view.html'
+        self.serializer_class = HarvestListSerializer
 
         response = super(HarvestViewset, self).list(request, *args, **kwargs)
         if request.accepted_renderer.format == 'json':

--- a/saskatoon/harvest/models.py
+++ b/saskatoon/harvest/models.py
@@ -553,6 +553,9 @@ class Harvest(models.Model):
         diff = datetime.datetime.now() - self.start_date
         return diff.days
 
+    def get_neighborhood(self):
+        return self.property.neighborhood
+
     # @property  # WARNING: decorator conflicts with property field :/
     def is_urgent(self):
         NUM_DAYS_URGENT_ORPHAN = 14

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -184,6 +184,31 @@ class HarvestSerializer(serializers.ModelSerializer):
         model = Harvest
         fields = '__all__'
 
+
+class HarvestTreeTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = TreeType
+        fields = ['id', 'name', 'fruit_name']
+
+
+class HarvestListSerializer(HarvestSerializer):
+    property = serializers.StringRelatedField(many=False)
+    neighborhood = serializers.ReadOnlyField(source='get_neighborhood')
+    trees = HarvestTreeTypeSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Harvest
+        fields = ['id',
+                  'start_date',
+                  'start_time',
+                  'end_time',
+                  'status',
+                  'pick_leader',
+                  'trees',
+                  'property',
+                  'neighborhood']
+
+
 # Community serializer
 class CommunitySerializer(serializers.ModelSerializer):
     person = PersonSerializer(many=False, read_only=True)

--- a/saskatoon/sitebase/templates/app/list_views/harvest/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/harvest/data_row.html
@@ -22,7 +22,7 @@
         <div class="text-nowrap">{{ tree.name }} {{ tree.fruit_name|get_fruit_name_icon }}</div>
         {% endfor %}
     </td>
-    <td>{{ harvest.property.neighborhood.name }}</td>
+    <td>{{ harvest.neighborhood }}</td>
     <td>
         {% if harvest.status == "Succeeded" %}
         <div class="skill">


### PR DESCRIPTION
## Type of change:
- [x] Refactor
----------
## What's Changed:
1- Added `get_neighborhood()` method to the Harvest Model to stop relying on the nested property serializer. (instead of using `harvest.property.neighborhood` in the table)
2- Added `HarvestTreetypeSerializer` with less fields.
3- Added `HarvestListSerializer` for the Harvest list view.
4- Changed `harvest.property.neighborhood.name` to `harvest.neighborhood` using the neighborhood field in the `HarvestListSerializer`. (check 1)

--------
## Screenshots:
1. before: 
![image](https://user-images.githubusercontent.com/52796958/175817618-cac792da-6f4f-4278-b4d1-32ee6518d782.png)

2. after:
![image](https://user-images.githubusercontent.com/52796958/175817458-eaacbf31-aafb-477e-ac54-d5c198fbe7fe.png)

--------
## Affected URLs:
127.0.0.1:8000/harvest/

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.