### PR TITLE
Fix show harvest status community list

### DIFF
--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -24,7 +24,7 @@ class PersonHarvestSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Harvest
-        fields = ['id', 'pick_leader', 'property']
+        fields = ['id', 'pick_leader', 'property', 'status']
 
 
 class PersonBeneficiarySerializer(serializers.ModelSerializer):


### PR DESCRIPTION
## Type of change:
- [x] Bug fix (change which fixes an issue).
----------
## What's Changed:
- harvest status wasn't shown on the community list page.

--------
## Screenshots:
1. 
![image](https://user-images.githubusercontent.com/52796958/176465701-2663bf89-8efd-414b-8f53-698c7a35027a.png)

2. 
![image](https://user-images.githubusercontent.com/52796958/176465374-407552fe-d921-4f92-ab6d-e7db0043ea4e.png)


--------
## Affected URLs:
127.0.0.1:8000/community/