### PR TITLE
Hotfix: pass pickleader.person to recipient-select form

### DIFF
--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -61,8 +61,8 @@ class HarvestViewset(LoginRequiredMixin, viewsets.ModelViewSet):
         requests = RequestForParticipation.objects.filter(harvest=harvest)
         distribution = HarvestYield.objects.filter(harvest=harvest)
         comments = Comment.objects.filter(harvest=harvest).order_by('-created_date')
-        property = harvest.property
-        pickers = [harvest.pick_leader] + [r.picker for r in requests.filter(is_accepted=True)]
+        pickers = [r.picker for r in requests.filter(is_accepted=True)]
+        pickers.append(harvest.pick_leader.person)
         organizations = Organization.objects.filter(is_beneficiary=True)
 
         return Response({'harvest': response.data,
@@ -75,7 +75,7 @@ class HarvestViewset(LoginRequiredMixin, viewsets.ModelViewSet):
                          'requests': requests,
                          'distribution': distribution,
                          'comments': comments,
-                         'property': property,
+                         'property': harvest.property,
                          'pickers': pickers,
                          'organizations': organizations,
                          'form_edit_recipient': HarvestYieldForm(),


### PR DESCRIPTION

Fixes #331
----------
## Type of change:
- [x] Bug fix (change which fixes an issue).
- [ ] New feature (change which adds functionality).
- [ ] Changes to models (requires making migrations).
- [ ] Documentation change.
----------
## What's Changed:
HarvestYield recipient must be an Actor, now passing only persons to recipient-select

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.