### PR TITLE
Allow participation requests at any time for authenticated users

### DIFF
--- a/saskatoon/harvest/models.py
+++ b/saskatoon/harvest/models.py
@@ -583,11 +583,9 @@ class Harvest(models.Model):
         return (timezone.now() > self.publication_date)
 
     def is_open_to_requests(self):
-        HOURS_OPEN_BEFORE_HARVEST = 2
         if self.status != 'Date-scheduled':
             return False
-        dt = datetime.timedelta(hours=HOURS_OPEN_BEFORE_HARVEST)
-        return timezone.now() + dt <= self.start_date
+        return timezone.now() <= self.end_date
 
 
 class RequestForParticipation(models.Model):

--- a/saskatoon/sitebase/templates/app/participation_create.html
+++ b/saskatoon/sitebase/templates/app/participation_create.html
@@ -8,7 +8,7 @@
 
 {{ form.media }}
 
-{% if harvest.is_open_to_requests == True %}
+{% if request.user.is_authenticated or harvest.is_open_to_requests == True %}
 
 <div class="breadcomb-area">
     <div class="container">


### PR DESCRIPTION
## Type of change:
- [x] Bug fix (change which fixes an issue).
- [ ] New feature (change which adds functionality).
- [ ] Changes to models (requires making migrations).
- [ ] Documentation change.
----------
## What's Changed:
- a logged-in user can fill out a participation request form at any time
- pulic registration is blocked past the harvest end datetime

Note this does not affect the display on the calendar. If a harvest status is kept at "Date-Scheduled", it will still appear as opened on the calendar and the Participate button will still appear. So pickleaders must manually set the status to Ready to prevent people from clicking on Participate.
If the status is kept at Date-scheduled nonetheless and harvest.end_date is past when clicking on the Participate button in the modal:
- it will work if user is authenticated
- it will prompt red error message if user is not logged in

We can further discuss if we want the calendar display to reflect the value returned by `is_open_to_registration`. It will require more changes.

--------
## Affected URLs:
http://localhost:8000/participation/create?hid=<hid>

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
