### PR TITLE
Speed up harvest detail view

### DIFF
--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -13,7 +13,7 @@ from member.models import AuthUser, Organization, Neighborhood, Person
 from harvest.models import (Equipment, Harvest, HarvestYield, Property,
                             RequestForParticipation, Comment, TreeType)
 from harvest.permissions import IsCoreOrAdmin
-from harvest.serializers import (HarvestListSerializer, HarvestSerializer, PropertyListSerializer, PropertySerializer, EquipmentSerializer,
+from harvest.serializers import (HarvestListSerializer, HarvestSerializer, HarvestDetailSerializer, PropertyListSerializer, PropertySerializer, EquipmentSerializer,
                                  CommunitySerializer, BeneficiarySerializer,
                                  RequestForParticipationSerializer)
 from harvest.utils import get_similar_properties
@@ -49,6 +49,7 @@ class HarvestViewset(LoginRequiredMixin, viewsets.ModelViewSet):
     # Harvest detail
     def retrieve(self, request, *args, **kwargs):
         self.template_name = 'app/detail_views/harvest/view.html'
+        self.serializer_class = HarvestDetailSerializer
         return super(HarvestViewset, self).retrieve(request, *args, **kwargs)
 
     def list(self, request, *args, **kwargs):

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -284,6 +284,26 @@ class HarvestTreeTypeSerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'fruit_name']
 
 
+class HarvestDetailSerializer(HarvestSerializer):
+    class Meta(HarvestSerializer.Meta):
+        fields = ['id',
+                  'pickers',
+                  'total_distribution',
+                  'start_date',
+                  'start_time',
+                  'end_time',
+                  'status',
+                  'pick_leader',
+                  'trees',
+                  'property',
+                  'requests',
+                  'harvestyield_set',
+                  'comment',
+                  'organizations',
+                  'about',
+                  'nb_required_pickers']
+
+
 class HarvestListSerializer(HarvestSerializer):
     property = serializers.StringRelatedField(many=False)
     neighborhood = serializers.ReadOnlyField(source='get_neighborhood')

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -284,7 +284,15 @@ class HarvestTreeTypeSerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'fruit_name']
 
 
+class HarvestBeneficiarySerializer(BeneficiarySerializer):
+    class Meta(BeneficiarySerializer.Meta):
+        fields = ['actor_id', 'civil_name']
+
+
 class HarvestDetailSerializer(HarvestSerializer):
+    trees = HarvestTreeTypeSerializer(many=True, read_only=True)
+    requests = RequestForParticipationSerializer(many=True, read_only=True)
+
     class Meta(HarvestSerializer.Meta):
         fields = ['id',
                   'pickers',
@@ -302,6 +310,11 @@ class HarvestDetailSerializer(HarvestSerializer):
                   'organizations',
                   'about',
                   'nb_required_pickers']
+
+    def get_organizations(self, obj):
+        organizations = Organization.objects.filter(
+            is_beneficiary=True)
+        return HarvestBeneficiarySerializer(organizations, many=True).data
 
 
 class HarvestListSerializer(HarvestSerializer):

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -51,8 +51,13 @@ class PersonSerializer(serializers.ModelSerializer):
                   'harvests_as_owner', 'organizations_as_contact', 'properties', 'comments']
 
 
+class RFPPersonSerializer(PersonSerializer):
+    class Meta(PersonSerializer.Meta):
+        fields = ['name', 'email', 'phone']
+
+
 class RequestForParticipationSerializer(serializers.ModelSerializer):
-    picker = PersonSerializer(many=False)
+    picker = RFPPersonSerializer(many=False)
     creation_date = serializers.DateTimeField( format=r"%Y-%m-%d")
     acceptation_date = serializers.DateTimeField( format=r"%Y-%m-%d")
 

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -289,27 +289,30 @@ class HarvestBeneficiarySerializer(BeneficiarySerializer):
         fields = ['actor_id', 'civil_name']
 
 
+class HarvestPropertySerializer(PropertySerializer):
+    neighborhood = serializers.StringRelatedField(many=False)
+
+    class Meta(PropertySerializer.Meta):
+        fields = ['id',
+                  'address',
+                  'owner',
+                  'neighborhood', ]
+
+
 class HarvestDetailSerializer(HarvestSerializer):
     trees = HarvestTreeTypeSerializer(many=True, read_only=True)
+    property = HarvestPropertySerializer(many=False, read_only=True)
     requests = RequestForParticipationSerializer(many=True, read_only=True)
 
-    class Meta(HarvestSerializer.Meta):
-        fields = ['id',
-                  'pickers',
-                  'total_distribution',
-                  'start_date',
-                  'start_time',
-                  'end_time',
-                  'status',
-                  'pick_leader',
-                  'trees',
-                  'property',
-                  'requests',
-                  'harvestyield_set',
-                  'comment',
-                  'organizations',
-                  'about',
-                  'nb_required_pickers']
+    class Meta:
+        model = Harvest
+        exclude = ['owner_present',
+                  'owner_help',
+                  'owner_fruit',
+                  'publication_date',
+                  'equipment_reserved',
+                  'creation_date',
+                  'changed_by']
 
     def get_organizations(self, obj):
         organizations = Organization.objects.filter(

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/about.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/about.html
@@ -10,7 +10,7 @@
                         <h2>{% trans "Public announcement" %}</h2>
                         <hr><br>
                         <h5>{% for tree in trees %} {{ tree.name }} {{ tree.fruit_name|get_fruit_name_icon }},{% endfor %}
-                            {{ property.neighborhood.name }}</h5>
+                            {{ property.neighborhood }}</h5>
                         <br>
                         <h4>{{start_date}}</h4>
                         <h5>{{start_time}} {% trans "to" %} {{end_time}}</h5>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/breadcomb.html
@@ -16,7 +16,7 @@
                                     <h1>#{{ id }}:
                                         {% for tree in trees %} {{ tree.name }} {{ tree.fruit_name|get_fruit_name_icon }}, {% endfor %}
                                         {{ property.address }},
-                                        {{ property.neighborhood.name }}
+                                        {{ property.neighborhood }}
                                     </h1>
                                 </div>
                             </div>


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->
Fixes #336
----------
## Type of change:
- [x] Refactor
----------
## What's Changed:
- Added `RFPPersonSerializer` instead of using the full person serializer for the RFPs.
- Added Harvest Detail serializer inheriting from the harvest serializer.
- Added a smaller benificiary serilaizer to be used with `get_organisation()` (this took the most time to load as we're loading all organizations)
- Added Harvest Property serializer inheriting from the Property serializer. And changed some templates to adapt to the changes.
- Changed the serializer class used in the Harvest Detail View.

--------
## Screenshots:
1. before:
![image](https://user-images.githubusercontent.com/52796958/179027345-cd2f5eaa-9706-4c94-83f3-e8583f16f7b5.png)

2. after:
![image](https://user-images.githubusercontent.com/52796958/179027648-cd076b8a-f053-4111-8157-efe1fc4dbd4e.png)


--------
## Affected URLs:
http://127.0.0.1:8000/harvest/870/

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
