### PR TITLE
Add a button to change harvest pickleader & a dropdown to change status

### DIFF
--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -10,7 +10,7 @@ from harvest.filters import (HarvestFilter, PropertyFilter, EquipmentFilter,
                              OrganizationFilter, CommunityFilter)
 from harvest.forms import (RequestForm, RFPManageForm, CommentForm, HarvestYieldForm)
 from member.models import AuthUser, Organization, Neighborhood, Person
-from harvest.models import (Equipment, Harvest, HarvestYield, Property,
+from harvest.models import (HARVESTS_STATUS_CHOICES, Equipment, Harvest, HarvestYield, Property,
                             RequestForParticipation, Comment, TreeType)
 from harvest.permissions import IsCoreOrAdmin
 from harvest.serializers import (HarvestListSerializer, HarvestSerializer, PropertyListSerializer, PropertySerializer, EquipmentSerializer,
@@ -65,6 +65,13 @@ class HarvestViewset(LoginRequiredMixin, viewsets.ModelViewSet):
         if harvest.pick_leader:
           pickers.append(harvest.pick_leader.person)
         organizations = Organization.objects.filter(is_beneficiary=True)
+        status_options = (
+            harvest_status_choice_tuple[0]
+            for harvest_status_choice_tuple
+            in HARVESTS_STATUS_CHOICES
+            if harvest_status_choice_tuple[0]
+            not in (harvest.status, "Adopted", "Orphan")
+        )
 
         return Response({'harvest': response.data,
                          'harvest_date': harvest.get_local_start().strftime("%a. %b. %-d, %Y"),
@@ -80,6 +87,7 @@ class HarvestViewset(LoginRequiredMixin, viewsets.ModelViewSet):
                          'pickers': pickers,
                          'organizations': organizations,
                          'form_edit_recipient': HarvestYieldForm(),
+                         'status_options': status_options,
                         })
 
     def list(self, request, *args, **kwargs):

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -202,6 +202,18 @@ class EquipmentSerializer(serializers.ModelSerializer):
         model = Equipment
         fields = '__all__'
 
+
+class PickLeaderSerializer(serializers.ModelSerializer):
+    name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = AuthUser
+        fields = ['id', 'name']
+
+    def get_name(self, obj):
+        return obj.person.name
+
+
 # Harvest serializer
 class HarvestSerializer(serializers.ModelSerializer):
 
@@ -215,8 +227,8 @@ class HarvestSerializer(serializers.ModelSerializer):
     end_time = serializers.DateTimeField(source='get_local_end', format="%H:%M")
     # # 2) get string rather than id from a pk
     status = serializers.StringRelatedField(many=False)
-    pick_leader = serializers.StringRelatedField(many=False)
     # 3) get the full instance from another serializer class
+    pick_leader = PickLeaderSerializer(many=False, read_only=True)
     trees = TreeTypeSerializer(many=True, read_only=True)
     property = PropertySerializer(many=False, read_only=True)
 

--- a/saskatoon/harvest/urls.py
+++ b/saskatoon/harvest/urls.py
@@ -43,6 +43,10 @@ urlpatterns = [
          views.harvest_leave,
          name='harvest-leave'),
 
+     path(r'harvest/status-change/<int:id>/',
+         views.harvest_status_change,
+         name='harvest-status-change'),
+
     path(r'participation/create/',
          views.RequestForParticipationCreateView.as_view(),
          name='rfp-create'),

--- a/saskatoon/harvest/urls.py
+++ b/saskatoon/harvest/urls.py
@@ -35,6 +35,14 @@ urlpatterns = [
          views.HarvestCreateView.as_view(),
          name='harvest-create'),
 
+     path(r'harvest/adopt/<int:id>/',
+         views.harvest_adopt,
+         name='harvest-adopt'),
+
+     path(r'harvest/leave/<int:id>/',
+         views.harvest_leave,
+         name='harvest-leave'),
+
     path(r'participation/create/',
          views.RequestForParticipationCreateView.as_view(),
          name='rfp-create'),

--- a/saskatoon/harvest/views.py
+++ b/saskatoon/harvest/views.py
@@ -329,20 +329,20 @@ def harvest_status_change(request, id):
     Used in a dropdown at harvest detail status template
     """
     harvest = get_object_or_404(Harvest, id=id)
-    current_user = request.user
-    status: str = request.GET['status']
+    request_status: str = request.GET['status']
 
-    if harvest.pick_leader == current_user and harvest.status != status:
-        harvest.status = status
+    if (request.user == harvest.pick_leader
+            and harvest.status != request_status):
+        harvest.status = request_status
         harvest.save()
         messages.success(
             request,
-            _("You changed the Harvest Status to: '{}'!".format(status))
+            _("You have set this harvest's status to: {}".format(request_status))
         )
-    elif harvest.status == status:
+    elif harvest.status == request_status:
         messages.warning(request, _(
-            "The Harvest Status is already set to '{}'!".format(harvest.status)))
+            "This harvest's status is already set to: {}".format(harvest.status)))
     else:
-        messages.warning(request, _("You are not the Harvest's pick leader!"))
+        messages.warning(request, _("You are not this harvest's pick leader!"))
 
     return HttpResponseRedirect(request.META.get('HTTP_REFERER'))

--- a/saskatoon/harvest/views.py
+++ b/saskatoon/harvest/views.py
@@ -8,7 +8,7 @@ from django.contrib.humanize.templatetags.humanize import ordinal
 
 from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 
 from django.views.generic import TemplateView, CreateView, UpdateView
 
@@ -16,7 +16,6 @@ from harvest.forms import (PropertyForm, PropertyCreateForm, PublicPropertyForm,
                            EquipmentForm, HarvestForm, RequestForm, RFPManageForm, CommentForm)
 from harvest.models import (Equipment, Harvest, HarvestYield, Property,
                             RequestForParticipation, Comment)
-from member.models import AuthUser
 
 
 class EquipmentCreateView(LoginRequiredMixin, SuccessMessageMixin, CreateView):
@@ -277,3 +276,47 @@ def harvest_yield_create(request):
             messages.success(request, _("New Fruit Recipient successfully added!"))
 
         return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
+
+
+@login_required
+def harvest_adopt(request, id):
+    """
+    Adds harvest pickleader and changes status to Adopted
+    Used in a button at harvest-detail/status template
+    """
+    harvest = get_object_or_404(Harvest, id=id)
+    user_is_core_or_pick: bool = request.user.groups.filter(
+        name__in=["pickleader", "core"]
+    ).exists() # checks if user is in the core or pick leader groups
+
+    if user_is_core_or_pick and harvest.pick_leader is None:
+        harvest.pick_leader = request.user
+        harvest.status = 'Adopted'
+        harvest.save()
+        messages.success(request, _("You adopted this harvest!"))
+    elif not user_is_core_or_pick:
+        messages.warning(request, _("You can't adopt this harvest!"))
+    else:
+        messages.warning(request, _(
+            "This harvest already has a pick leader!"))
+
+    return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
+
+
+@login_required
+def harvest_leave(request, id):
+    """
+    Removes harvest pickleader and changes status to Orphan
+    Used in a button at harvest-detail/status template
+    """
+    harvest = get_object_or_404(Harvest, id=id)
+
+    if harvest.pick_leader == request.user:
+        harvest.pick_leader = None
+        harvest.status = 'Orphan'
+        harvest.save()
+        messages.success(request, _("You successfully left this harvest!"))
+    else:
+        messages.warning(request, _("You are not this harvest's pick leader!"))
+
+    return HttpResponseRedirect(request.META.get('HTTP_REFERER'))

--- a/saskatoon/harvest/views.py
+++ b/saskatoon/harvest/views.py
@@ -320,3 +320,29 @@ def harvest_leave(request, id):
         messages.warning(request, _("You are not this harvest's pick leader!"))
 
     return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
+
+
+@login_required
+def harvest_status_change(request, id):
+    """
+    Changes harvest status
+    Used in a dropdown at harvest detail status template
+    """
+    harvest = get_object_or_404(Harvest, id=id)
+    current_user = request.user
+    status: str = request.GET['status']
+
+    if harvest.pick_leader == current_user and harvest.status != status:
+        harvest.status = status
+        harvest.save()
+        messages.success(
+            request,
+            _("You changed the Harvest Status to: '{}'!".format(status))
+        )
+    elif harvest.status == status:
+        messages.warning(request, _(
+            "The Harvest Status is already set to '{}'!".format(harvest.status)))
+    else:
+        messages.warning(request, _("You are not the Harvest's pick leader!"))
+
+    return HttpResponseRedirect(request.META.get('HTTP_REFERER'))

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
@@ -38,7 +38,6 @@
                             <h2><span class="counter">{{ requests.count }}</span>
                                 / {{ harvest.nb_required_pickers }}</h2>
                         </div>
-                        <div class="sparkline-bar-stats2">1,4,8,3,5,6,4,8,3,3,9,5</div>
                     {% endif %}
                 </div>
             </div>
@@ -47,10 +46,42 @@
                 <div class="wb-traffic-inner notika-shadow sm-res-mg-t-30 tb-res-mg-t-30 dk-res-mg-t-30">
                     <div class="website-traffic-ctn">
                         <p>{% trans "Pick leader" %}</p>
-                        {% if harvest.pick_leader != None %}
-                        <h2>{{ harvest.pick_leader }}</h2>
+                        {% if harvest.pick_leader is None %}
+                        <div class="row">
+                            <div class="col-lg-8">
+                                <h2>{% trans "Missing" %}</h2>
+                            </div>
+                            <div class="col-lg-4 breadcomb-report">
+                                <a href="{% url 'harvest-adopt' harvest.id %}">
+                                    <button
+                                    data-placement="left"
+                                    title="Adopt it!"
+                                    class="btn"
+                                    >
+                                        {% trans "Adopt it!" %}
+                                    </button>
+                                </a>
+                            </div>
+                        </div>
+                        {% elif harvest.pick_leader.id == request.user.id %}
+                        <div class="row">
+                            <div class="col-lg-7">
+                                <h2>{{ harvest.pick_leader.name }}</h2>
+                            </div>
+                            <div class="col-lg-5 breadcomb-report">
+                                <a href="{% url 'harvest-leave' harvest.id %}">
+                                    <button
+                                    data-placement="left"
+                                    title="Leave it!"
+                                    class="btn"
+                                    >
+                                        {% trans "Leave it!" %}
+                                    </button>
+                                </a>
+                            </div>
+                        </div>
                         {% else %}
-                        <h2>{% trans "Missing" %}</h2>
+                        <h2>{{ harvest.pick_leader.name }}</h2>
                         {% endif %}
                     </div>
                 </div>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
@@ -10,11 +10,56 @@
                 <div class="wb-traffic-inner notika-shadow sm-res-mg-t-30 tb-res-mg-t-30">
                     <div class="website-traffic-ctn">
                         <p>{% translate 'Harvest status' %}</p>
+                        {% if harvest.pick_leader is None or harvest.pick_leader.id != request.user.id %}
                         <h2>{{ harvest.status }}</h2>
+                        {% else %}
+                        <div class="dropdown">
+                            <button
+                            {% if harvest.status == 'Succeeded' %}
+                            class="btn btn-success dropdown-toggle"
+                            {% elif harvest.status == 'Cancelled' %}
+                            class="btn btn-danger dropdown-toggle"
+                            {% elif harvest.status == 'Ready' %}
+                            class="btn btn-primary dropdown-toggle"
+                            {% else %}
+                            class="btn btn-warning dropdown-toggle"
+                            {% endif %}
+                            type="button"
+                            id="harvest-status-dropdown"
+                            data-toggle="dropdown"
+                            >
+                                <p style="font-size: 1.5em; color:white;">
+                                    <strong>
+                                        {{ harvest.status }}
+                                        <span class="caret"></span>
+                                    </strong>
+                                </p>
+                            </button>
+                            <ul
+                            class="dropdown-menu"
+                            role="menu"
+                            aria-labelledby="menu1"
+                            >
+                                {% for status_option in status_options %}
+                                <li role="presentation">
+                                    <a
+                                    href="{% url 'harvest-status-change' harvest.id %}?status={{ status_option }}"
+                                    role="menuitem"
+                                    tabindex="-1"
+                                    >
+                                    {{ status_option }}
+                                </a>
+                                </li>
+                                {% if not forloop.last %}
+                                <li role="presentation" class="divider"></li>
+                                {% endif %}
+                                {% endfor %}
+                            </ul>
+                        </div>
+                        {% endif %}
                     </div>
                 </div>
             </div>
-
             <div class="col-lg-3 col-md-6 col-sm-6 col-xs-12">
                 <div class="wb-traffic-inner notika-shadow sm-res-mg-t-30 tb-res-mg-t-30">
                     <div class="website-traffic-ctn">

--- a/saskatoon/sitebase/templates/app/list_views/harvest/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/harvest/data_row.html
@@ -104,7 +104,7 @@
     </td>
     <td>
         {% if harvest.pick_leader %}
-        {{ harvest.pick_leader|default:'' }}
+        {{ harvest.pick_leader.name|default:'' }}
         {% endif %}
     </td>
     <td>


### PR DESCRIPTION
<!-- 
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->
Fixes #199
----------
## Type of change:
- [x] New feature (change which adds functionality).
----------
## What's Changed:
- Added 2 `adopt_harvest` and `leave_harvest` views with their corresponding urls.
-  `adopt` checks if harvest has no pickleader, then it changes its status to `Adopted` and adds the user as a pickleader.
- `leave` does the vice-versa: checks if the user is the pickleader and so on...
- Added  a button beside the pickleader name to adopt/leave the harvest, doesn't get displayed if the harvest has another pickleader than the user.
- Added `harvest-status-change` view & url, also added `status_options` to the harvest detail context.
- Added a dropdown to change harvest status that appears if the user is the pickleader and if the harvest isn't orphaned.

--------
## Screenshots:

1.
![image](https://user-images.githubusercontent.com/52796958/179808130-40981d9e-4cce-4634-8f82-9e37d37df375.png)

2. trying to adopt harvest when there's already a pickleader
![image](https://user-images.githubusercontent.com/52796958/179808501-df92cf72-8c4c-42e6-876f-72a9016138cb.png)

3.
![image](https://user-images.githubusercontent.com/52796958/179807999-b61903f2-1108-48c6-a04c-862668196fbb.png)

4. Harvest status dropdown
![image](https://user-images.githubusercontent.com/52796958/179996937-1d35e987-5019-402f-b7dc-aa70e4dc4725.png)


--------
## URLs:
- http://127.0.0.1:8000/harvest/id/
- http://127.0.0.1:8000/harvest/adopt/id/
- http://127.0.0.1:8000/harvest/leave/id/
- http://127.0.0.1:8000/harvest/status-change/id/?status=

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
