### PR TITLE
Fix edge-case crashes + Owner autocomplete

### DIFF
--- a/saskatoon/member/autocomplete.py
+++ b/saskatoon/member/autocomplete.py
@@ -106,4 +106,4 @@ class OwnerAutocomplete(autocomplete.Select2QuerySetView):
             q2 = Q(organization__civil_name__icontains=self.q)
             qs = qs.filter(q0 | q1 | q2)
 
-        return qs.distinc()
+        return qs.distinct()

--- a/saskatoon/sitebase/templates/app/detail_views/property/similar_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/similar_row.html
@@ -11,27 +11,30 @@
     <td> {{ property.neighborhood }} </td>
     <td> {% include 'app/list_views/property/status.html' %} </td>
 
-    <td>
-        {% if property.owner %}
+    {% if property.owner %}
+        <td>
             {{ property.owner }} &nbsp;
             {% if property.owner.is_person and perms.member.change_person %}
                 <small><a href="{% url 'person-update' property.owner.pk %}" title="edit">
                         <i class="fa fa-pencil"></i>
                     </a></small>
             {% endif %}
-        {% endif %}
-    </td>
-    <td>
-        {% if property.owner.is_person %}
-            {% with property.owner.person as po %}
-                <a href="mailto:{{po.email}}">{{ po.email }}</a> &nbsp;
-                {{ po.phone|default_if_none:"" }}
-            {% endwith %}
-        {% elif property.owner.is_organization %}
-            {% with property.owner.organization.contact_person as po %}
-                <a href="mailto:{{po.email}}">{{ po.email }}</a> &nbsp;
-                {{ po.phone|default_if_none:"" }}
-            {% endwith %}
-        {% endif %}
-    </td>
+        </td>
+        <td>
+            {% if property.owner.is_person %}
+                {% with property.owner.person as po %}
+                    <a href="mailto:{{po.email}}">{{ po.email }}</a> &nbsp;
+                    {{ po.phone|default_if_none:"" }}
+                {% endwith %}
+            {% elif property.owner.is_organization %}
+                {% with property.owner.organization.contact_person as po %}
+                    <a href="mailto:{{po.email}}">{{ po.email }}</a> &nbsp;
+                    {{ po.phone|default_if_none:"" }}
+                {% endwith %}
+            {% endif %}
+        </td>
+    {% else %}
+        <td></td>
+        <td></td>
+    {% endif %}
 </tr>

--- a/saskatoon/sitebase/templates/app/detail_views/property/similar_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/similar_row.html
@@ -12,17 +12,26 @@
     <td> {% include 'app/list_views/property/status.html' %} </td>
 
     <td>
-        {% if perms.member.change_person %}
+        {% if property.owner %}
             {{ property.owner }} &nbsp;
-            <small><a href="{% url 'person-update' property.owner.pk %}" title="edit">
-                <i class="fa fa-pencil"></i>
-            </a></small>
+            {% if property.owner.is_person and perms.member.change_person %}
+                <small><a href="{% url 'person-update' property.owner.pk %}" title="edit">
+                        <i class="fa fa-pencil"></i>
+                    </a></small>
+            {% endif %}
         {% endif %}
     </td>
     <td>
-        {% with property.owner as po %}
-            <a href="mailto:{{po.email}}">{{ po.email }}</a> &nbsp;
-            {{ po.phone }}
-        {% endwith %}
+        {% if property.owner.is_person %}
+            {% with property.owner.person as po %}
+                <a href="mailto:{{po.email}}">{{ po.email }}</a> &nbsp;
+                {{ po.phone|default_if_none:"" }}
+            {% endwith %}
+        {% elif property.owner.is_organization %}
+            {% with property.owner.organization.contact_person as po %}
+                <a href="mailto:{{po.email}}">{{ po.email }}</a> &nbsp;
+                {{ po.phone|default_if_none:"" }}
+            {% endwith %}
+        {% endif %}
     </td>
 </tr>

--- a/saskatoon/sitebase/templates/app/list_views/beneficiary/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/beneficiary/data_row.html
@@ -38,8 +38,7 @@
 
     <td>
         <b>{{ org.contact_person.name }}</b>
-
-        {% if perms.member.change_person %}
+        {% if org.contact_person and perms.member.change_person %}
             &nbsp;
             <small><a href="{% url 'person-update' org.contact_person.actor_id %}"
                     title="edit">


### PR DESCRIPTION
## Bug fixes (master branch)
- Fix #357
- Fix beneficiary list view cannot load if one `contact_person` in None for one of the organizations
- Fix Owner autocomplete (typo)

----------
## What's Changed:
- do not assume pending property owner exists in similar properties list
- properly differentiate organization owners from persons in `similar_row.html`
- do not assume contact_person exist in beneficiary list

## Affected URLs
- http://localhost:8000/property/
- http://localhost:8000/beneficiary/
- http://localhost:8000/owner-autocomplete/

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
