### PR TITLE
fix integrity error on get_or_create authuser

### DIFF
--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -300,7 +300,7 @@ class PropertyCreateForm(PropertyForm):
                 validate_email(data['owner_email'])
             else:
                 raise forms.ValidationError(
-                    _("ERROR: You must either select an Owner \
+                    _("You must either select an Owner \
                     or create a new one and provide their personal information"))
         return data
 

--- a/saskatoon/member/forms.py
+++ b/saskatoon/member/forms.py
@@ -107,9 +107,12 @@ class PersonUpdateForm(forms.ModelForm):
         validate_email(email, self.auth_user)
 
         roles = self.cleaned_data.get('roles', None)
-        if self.auth_user and not roles:
+        if email and not roles:
             raise forms.ValidationError(
                 _("Please assign at least one role to the user"))
+        elif roles and not email:
+            raise forms.ValidationError(
+                _("An email address is required to assign a role to the user"))
 
     def save(self):
         instance = super().save()

--- a/saskatoon/member/forms.py
+++ b/saskatoon/member/forms.py
@@ -107,18 +107,19 @@ class PersonUpdateForm(forms.ModelForm):
         validate_email(email, self.auth_user)
 
         roles = self.cleaned_data.get('roles', None)
-        if email and not roles:
+        if self.auth_user and not roles:
             raise forms.ValidationError(
-                _("ERROR: Please assign at least one role to the user"))
+                _("Please assign at least one role to the user"))
 
     def save(self):
         instance = super().save()
         email = self.cleaned_data.get('email', None)
         roles = self.cleaned_data.get('roles', None)
         if email and roles:
-            auth_user, created = AuthUser.objects.get_or_create(person=instance)
-            auth_user.email = email
-            auth_user.set_roles(roles)  # calls auth_user.save()
+            if not self.auth_user:
+                self.auth_user = AuthUser.objects.create(person=instance, email=email)
+            self.auth_user.email = email
+            self.auth_user.set_roles(roles)  # calls auth_user.save()
 
 
 class OrganizationForm(forms.ModelForm):

--- a/saskatoon/member/validators.py
+++ b/saskatoon/member/validators.py
@@ -7,14 +7,13 @@ from member.models import AuthUser
 def validate_email(email, auth_user=None):
     '''Check if a user with same email address is already registered'''
 
-    if auth_user and not email:
+    if email:
+        duplicates = AuthUser.objects.filter(email=email)
+        if auth_user:
+            duplicates = duplicates.exclude(id=auth_user.id)
+        if duplicates.exists():
+            raise ValidationError(
+                _("Email address < {} > is already registered!").format(email)
+            )
+    elif auth_user:
         raise ValidationError(_("Please enter an email address."))
-
-    duplicates = AuthUser.objects.filter(email=email)
-    if auth_user:
-        duplicates = duplicates.exclude(id=auth_user.id)
-
-    if duplicates.exists():
-        raise ValidationError(
-            _("Email address < {} > is already registered!").format(email)
-        )

--- a/saskatoon/member/validators.py
+++ b/saskatoon/member/validators.py
@@ -8,7 +8,7 @@ def validate_email(email, auth_user=None):
     '''Check if a user with same email address is already registered'''
 
     if auth_user and not email:
-        raise ValidationError(_("ERROR: New email address cannot be empty."))
+        raise ValidationError(_("Please enter an email address."))
 
     duplicates = AuthUser.objects.filter(email=email)
     if auth_user:
@@ -16,5 +16,5 @@ def validate_email(email, auth_user=None):
 
     if duplicates.exists():
         raise ValidationError(
-            _("ERROR: email address < {} > is already registered!").format(email)
+            _("Email address < {} > is already registered!").format(email)
         )


### PR DESCRIPTION
When saving a `PersonUpdateForm`, if email and roles are provided but the person is not yet associated with an AuthUser, one should be created automatically. The `get_or_create` method called during `save` will first assign an empty string for the email, which then  gets updated right after (passing email to `get_or_create` would break the flow of changing an existing auth_user email). However if the database happens to have an AuthUser with an empty string as email an Integrity error is thrown when `get_or_create` tries to create a new one.

This PR avoids this method and makes use of the fact `self.auth_user` was already stored during `__init__`

## Type of change:
- [x] Bug fix (change which fixes an issue).
- [ ] New feature (change which adds functionality).
- [ ] Changes to models (requires making migrations).
- [ ] Documentation change.
----------
## What's Changed:
- fix create auth_user if it does not exist in `PersonUpdateForm`
- make sure email address is provided if a role is selected
- make sure empty email does not trigger duplicate error
- cosmetic changes on form validation strings



--------
## Affected URLs:
e.g. `localhost:8000/person/update/pk/?pid=pid`

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] New and existing unit tests pass locally with my changes.
