### PR TITLE
feat: password reset email view

### DIFF
--- a/saskatoon/member/urls.py
+++ b/saskatoon/member/urls.py
@@ -29,6 +29,9 @@ urlpatterns = [
          views.PasswordChangeView.as_view(),
          name ='change_password'),
 
+    path('reset_password/<int:pk>',
+         views.PasswordResetView.as_view(),
+         name ='reset_password'),
 
     # AUTO-COMPLETE VIEWS
     re_path(r'^actor-autocomplete/$',

--- a/saskatoon/member/views.py
+++ b/saskatoon/member/views.py
@@ -154,7 +154,6 @@ class PasswordChangeView(auth_views.PasswordChangeView):
 class PasswordResetView(LoginRequiredMixin, PermissionRequiredMixin, SuccessMessageMixin, View):
     """View for sending reset password email, with redirect on success."""
     permission_required = 'member.change_authuser'
-    template_name = 'app/index.html'
 
     def dispatch(self, request, *args, **kwargs):
         target_user = AuthUser.objects.get(id=self.kwargs['pk'])

--- a/saskatoon/member/views.py
+++ b/saskatoon/member/views.py
@@ -165,7 +165,6 @@ class PasswordResetView(LoginRequiredMixin, PermissionRequiredMixin, SuccessMess
 
         subject = "Les Fruits Défendus - Password reset"
 
-        # FIXME: Add French content
         message = """Hi {name},
 
 Your password for the Saskatoon harvest management platform has been reset by an administrator from Les Fruits Défendus. \

--- a/saskatoon/member/views.py
+++ b/saskatoon/member/views.py
@@ -159,7 +159,11 @@ class PasswordResetView(LoginRequiredMixin, PermissionRequiredMixin, SuccessMess
     def dispatch(self, request, *args, **kwargs):
         target_user = AuthUser.objects.get(id=self.kwargs['pk'])
 
-        subject = ""Les Fruits Défendus - Password reset"
+        if target_user.password == '':
+            messages.error(request, _("Cannot reset password for {email}: User does not have a password set.".format(email=target_user.email)))
+            return redirect('community-list')
+
+        subject = "Les Fruits Défendus - Password reset"
 
         # FIXME: Add French content
         message = """Hi {name},

--- a/saskatoon/member/views.py
+++ b/saskatoon/member/views.py
@@ -159,13 +159,13 @@ class PasswordResetView(LoginRequiredMixin, PermissionRequiredMixin, SuccessMess
     def dispatch(self, request, *args, **kwargs):
         target_user = AuthUser.objects.get(id=self.kwargs['pk'])
 
-        subject = "Your password has been reset"
+        subject = ""Les Fruits Défendus - Password reset"
 
         # FIXME: Add French content
         message = """Hi {name},
 
-You are receiving this email because an administrator for Les Fruits Défendus has reset your password. \
-Please log in using the temporary password provided below.
+Your password for the Saskatoon harvest management platform has been reset by an administrator from Les Fruits Défendus. \
+Please log in using the temporary credentials provided below and follow the steps to update your new password.
 
 Login page: https://saskatoon.lesfruitsdefendus.org/accounts/login/
 Email address: {email}
@@ -177,7 +177,8 @@ Thanks for supporting your community!
 
 Bonjour {name},
 
-<>
+Votre mot de passe pour la plateforme de gestion Saskatoon a été réinitialisé par un.e administrateur.ice des Fruits Défendus. \
+Merci de vous connecter en utilisant les identifiants fournis plus bas et de suivre les instructions pour remettre à jour votre nouveau mot de passe.
 
 Page de connexion: https://saskatoon.lesfruitsdefendus.org/accounts/login/
 Adresse électronique: {email}

--- a/saskatoon/member/views.py
+++ b/saskatoon/member/views.py
@@ -161,7 +161,34 @@ class PasswordResetView(LoginRequiredMixin, PermissionRequiredMixin, SuccessMess
 
         subject = "Your password has been reset"
 
-        message = ""
+        # FIXME: Add French content
+        message = """Hi {name},
+
+You are receiving this email because an administrator for Les Fruits Défendus has reset your password. \
+Please log in using the temporary password provided below.
+
+Login page: https://saskatoon.lesfruitsdefendus.org/accounts/login/
+Email address: {email}
+Temporary password: {{password}}
+
+Thanks for supporting your community!
+
+--
+
+Bonjour {name},
+
+<>
+
+Page de connexion: https://saskatoon.lesfruitsdefendus.org/accounts/login/
+Adresse électronique: {email}
+Mot de passe temporaire: {{password}}
+
+Merci de soutenir votre communauté!
+
+--
+
+Les Fruits Défendus
+""".format(name=target_user.person.first_name, email=target_user.email)
 
         if send_reset_password_email(target_user, subject, message):
             messages.success(request, _("Password reset email successfully sent to {email}".format(email=target_user.email)))

--- a/saskatoon/sitebase/templates/app/list_views/community/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/community/data_row.html
@@ -24,18 +24,11 @@
         </span><br>
         <a href='mailto:{{user.email}}'>{{ user.email }}</a> &nbsp;
         {% if perms.member.change_authuser %}
-            {% if 'core' in user.role_codes or 'pickleader' in user.role_codes %}
-                <a href="{% url 'admin:auth_user_password_change' user.id %}"
+            <a href="{% url 'reset_password' user.id %}"
                 onclick="return confirm('{% trans "Are you sure you want to reset this user password?" %}');"
-                {% if not user.password %}
-                    title="register-user"
-                    >
-                    <small class="btn btn-primary  waves-effect btn-sm"><i class="fa fa-plus"> </i> {% translate ' Register User' %} </a></small>
-                {% else %}
-                    title="reset-password">
-                    <small><i class="fa fa-refresh"></i></a></small>
-                {% endif %}
-            {% endif %}
+                title="reset-password">
+                <small><i class="fa fa-refresh"></i></small>
+            </a>
         {% endif %}
         <br>{{ user.person.phone|default:"" }}
     </td>

--- a/saskatoon/sitebase/templates/app/list_views/community/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/community/data_row.html
@@ -23,7 +23,7 @@
         {% endif %}
         </span><br>
         <a href='mailto:{{user.email}}'>{{ user.email }}</a> &nbsp;
-        {% if perms.member.change_authuser %}
+        {% if perms.member.change_authuser and user.password != '' %}
             <a href="{% url 'reset_password' user.id %}"
                 onclick="return confirm('{% trans "Are you sure you want to reset this user password?" %}');"
                 title="reset-password">


### PR DESCRIPTION
Changes behaviour of pressing password reset button (icon beside emails in Community page) to sending a a password reset email.

Removed secondary functionality of the same icon which registers a user without a password since that process is taken over by the onboarding registration process.

TODO:
- [x] Add French subtitles

Partially addresses #372 

----------
## Type of change:
- [ ] Bug fix (change which fixes an issue).
- [x] New feature (change which adds functionality).
- [ ] Changes to models (requires making migrations).
- [ ] Documentation change.
----------
## What's Changed:
- add `PasswordReset` view
- edit Community view template
- remove "Register User" functionality

--------
## Affected URLs:
- `127.0.0.1:8000/reset_password/`
- `127.0.0.1:8000/community/`

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
