### PR TITLE
Set default value for authorized filter in property-list view

### DIFF
--- a/saskatoon/harvest/views.py
+++ b/saskatoon/harvest/views.py
@@ -56,13 +56,17 @@ class PropertyCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateVie
     model = Property
     form_class = PropertyCreateForm
     template_name = 'app/forms/property_create_form.html'
-    success_url = reverse_lazy('property-list')
+    # TODO: redirect to property list once pagination is implemented
+    # success_url = reverse_lazy('property-list')
+    success_url = reverse_lazy('home')
     success_message = _("Property created successfully!")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['title'] = _("Add a new property")
-        context['cancel_url'] = reverse_lazy('property-list')
+        # TODO: redirect to property list once pagination is implemented
+        # context['cancel_url'] = reverse_lazy('property-list')
+        context['cancel_url'] = reverse_lazy('home')
         return context
 
 
@@ -125,7 +129,9 @@ class HarvestCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateView
             cancel_url = reverse_lazy('property-detail',
                                       kwargs={'pk': _property.id})
         else:
-            cancel_url = reverse_lazy('harvest-list')
+            # TODO: redirect to harvest list once pagination is implemented
+            # cancel_url = reverse_lazy('harvest-list')
+            cancel_url = reverse_lazy('home')
 
         context = super().get_context_data(**kwargs)
         context['title'] = _("Add a new harvest")

--- a/saskatoon/member/forms.py
+++ b/saskatoon/member/forms.py
@@ -18,7 +18,7 @@ class PersonCreateForm(forms.ModelForm):
 
     class Meta:
         model = Person
-        exclude = ['redmine_contact_id', 'longitude', 'latitude']
+        exclude = ['redmine_contact_id', 'longitude', 'latitude', 'onboarding']
 
     email = forms.EmailField(
         label=_("Email"),
@@ -72,7 +72,7 @@ class PersonUpdateForm(forms.ModelForm):
 
     class Meta:
         model = Person
-        exclude = ['redmine_contact_id', 'longitude', 'latitude']
+        exclude = ['redmine_contact_id', 'longitude', 'latitude', 'onboarding']
 
     roles = forms.MultipleChoiceField(
         widget=forms.CheckboxSelectMultiple,
@@ -131,7 +131,7 @@ class OnboardingPersonUpdateForm(forms.ModelForm):
 
     class Meta:
         model = Person
-        exclude = ['redmine_contact_id', 'longitude', 'latitude']
+        exclude = ['redmine_contact_id', 'longitude', 'latitude', 'onboarding']
 
     def save(self):
         super().save()

--- a/saskatoon/member/views.py
+++ b/saskatoon/member/views.py
@@ -44,7 +44,9 @@ class PersonCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateView)
             cancel_url = '/property/' + str(p.id)
         except KeyError:
             initial = None
-            cancel_url = reverse_lazy('community-list')
+            # TODO: redirect to community list once pagination is implemented
+            # cancel_url = reverse_lazy('community-list')
+            cancel_url = reverse_lazy('home')
 
         context = super().get_context_data(**kwargs)
         context['title'] = _("Person Registration")
@@ -57,7 +59,9 @@ class PersonCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateView)
             property_id = self.request.GET['pid']
             return reverse_lazy('property-detail', kwargs={'pk': property_id})
         except KeyError:
-            return reverse_lazy('community-list')
+            # TODO: redirect to community list once pagination is implemented
+            # return reverse_lazy('community-list')
+            return reverse_lazy('home')
 
     def form_invalid(self, form, **kwargs):
         context = self.get_context_data(**kwargs)
@@ -75,7 +79,9 @@ class PersonUpdateView(PermissionRequiredMixin, SuccessMessageMixin, UpdateView)
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['title'] = _("Person Update")
-        context['cancel_url'] = reverse_lazy('community-list')
+        # TODO: redirect to community list once pagination is implemented
+        # context['cancel_url'] = reverse_lazy('community-list')
+        context['cancel_url'] = reverse_lazy('home')
         return context
 
     def get_success_url(self):
@@ -83,7 +89,9 @@ class PersonUpdateView(PermissionRequiredMixin, SuccessMessageMixin, UpdateView)
             property_id = self.request.GET['pid']
             return reverse_lazy('property-detail', kwargs={'pk': property_id})
         except KeyError:
-            return reverse_lazy('community-list')
+            # TODO: redirect to community list once pagination is implemented
+            # return reverse_lazy('community-list')
+            return reverse_lazy('home')
 
     def get_form_kwargs(self, *args, **kwargs):
         """Pass request.user to form"""

--- a/saskatoon/sitebase/templates/app/base/menu.html
+++ b/saskatoon/sitebase/templates/app/base/menu.html
@@ -19,7 +19,7 @@
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'property-list' %}active{% endif %}">
                                 <!--TODO <a href="{% url 'community-list' %}">{% translate "Community" %}</a> -->
-                                <a href="{% url 'property-list' %}?is_active=true">{% translate "Properties" %}</a>
+                                <a href="{% url 'property-list' %}?is_active=true&authorized=2">{% translate "Properties" %}</a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'beneficiary-list' %}active{% endif %}">
                                 <a href="{% url 'beneficiary-list' %}">{% translate "Beneficiaries" %}</a>
@@ -59,7 +59,7 @@
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'property-list' %}active{% endif %}">
                         <!--TODO <a href="{% url 'property-list' %}"><i class="glyphicon glyphicon-tree-deciduous"></i> {% translate "Properties" %}</a> -->
-                        <a href="{% url 'property-list' %}?is_active=true"><i class="glyphicon glyphicon-tree-deciduous"></i> {% translate "Properties" %}</a>
+                        <a href="{% url 'property-list' %}?is_active=true&authorized=2"><i class="glyphicon glyphicon-tree-deciduous"></i> {% translate "Properties" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'beneficiary-list' %}active{% endif %}">
                         <a href="{% url 'beneficiary-list' %}"><i class="fa fa-gift"></i> {% translate "Beneficiaries" %}</a>


### PR DESCRIPTION
PR #320  introduced workarounds to reduce initial loading time when clicking on menu items despite pagination not being properly implemented. However loading time for the `Properties` is still problematic.

This PR: 
- sets the `Authorized` filter to `Not Yet Authorized` so that less properties are loaded at once when the `Properties` page is accessed from the menu. 
- prevents most redirects to `harvest-list`, `property-list` and `community-list` routes, forcing users to go through the menu buttons.