### PR TITLE
fix: languages dropdown missing options

### DIFF
--- a/saskatoon/sitebase/templates/app/base/header.html
+++ b/saskatoon/sitebase/templates/app/base/header.html
@@ -1,6 +1,9 @@
 {% load static %}
 {% load i18n %}
 {% load auth_users %}
+{% get_current_language as LANGUAGE_CODE %}
+{% get_available_languages as LANGUAGES %}
+{% get_language_info_list for LANGUAGES as languages %}
 <div class="header-top-area">
     <div class="container">
         <div class="row">

--- a/saskatoon/sitebase/templates/app/base/view.html
+++ b/saskatoon/sitebase/templates/app/base/view.html
@@ -1,8 +1,5 @@
 {% extends 'app/base/base.html' %}
 {% load i18n %}
-{% get_current_language as LANGUAGE_CODE %}
-{% get_available_languages as LANGUAGES %}
-{% get_language_info_list for LANGUAGES as languages %}
 {% load static %}
 {% block body %}
     <!--[if lt IE 8]>


### PR DESCRIPTION
Fix for languages missing in header dropdown.

Tags were left behind in `base/view.html` when refactored in a previous PR.

---

## Type of change:

- [x] Bug fix (change which fixes an issue).

---

## What's Changed:

- moved languages tags to header

---

## Affected URLs:

`*`

---

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
