### PR TITLE
Fix reset_password url conflict w/ auth_views

### DIFF
--- a/saskatoon/member/forms.py
+++ b/saskatoon/member/forms.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.utils.translation import gettext_lazy as _
 from django import forms
 from django.contrib.auth import forms as auth_forms
@@ -8,7 +7,7 @@ from django.forms.widgets import PasswordInput
 from dal import autocomplete
 from logging import getLogger
 from harvest.models import Property
-from member.models import AuthUser, Person, Organization, AUTH_GROUPS, STAFF_GROUPS
+from member.models import AuthUser, Person, Organization, AUTH_GROUPS
 from member.validators import validate_email, validate_new_password
 
 logger = getLogger('saskatoon')

--- a/saskatoon/member/urls.py
+++ b/saskatoon/member/urls.py
@@ -25,13 +25,13 @@ urlpatterns = [
          views.OrganizationUpdateView.as_view(),
          name='beneficiary-update'),
 
-    path('change_password/',
+    path('user/change_password/',
          views.PasswordChangeView.as_view(),
-         name ='change_password'),
+         name='change-password'),
 
-    path('reset_password/<int:pk>',
+    path('user/reset_password/<int:pk>',
          views.PasswordResetView.as_view(),
-         name ='reset_password'),
+         name='reset-password'),
 
     # AUTO-COMPLETE VIEWS
     re_path(r'^actor-autocomplete/$',

--- a/saskatoon/sitebase/templates/app/list_views/community/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/community/data_row.html
@@ -24,7 +24,7 @@
         </span><br>
         <a href='mailto:{{user.email}}'>{{ user.email }}</a> &nbsp;
         {% if perms.member.change_authuser and user.password != '' %}
-            <a href="{% url 'reset_password' user.id %}"
+            <a href="{% url 'reset-password' user.id %}"
                 onclick="return confirm('{% trans "Are you sure you want to reset this user password?" %}');"
                 title="reset-password">
                 <small><i class="fa fa-refresh"></i></small>

--- a/saskatoon/sitebase/templates/registration/change_password.html
+++ b/saskatoon/sitebase/templates/registration/change_password.html
@@ -6,7 +6,7 @@
     <div class="login-content">
         <!-- Login -->
         <div class="nk-block toggled" id="l-login">
-            <form action='{% url "change_password" %}' method="post">
+            <form action='{% url "change-password" %}' method="post">
                 {% csrf_token %}
                 <div class="nk-form">
                     <h1>Change password</h1>

--- a/saskatoon/sitebase/urls.py
+++ b/saskatoon/sitebase/urls.py
@@ -36,18 +36,18 @@ urlpatterns = [
 
     path('reset_password/',
          auth_views.PasswordResetView.as_view(),
-         name ='reset_password'),
+         name='reset_password'),
 
     path('reset_password_sent/',
          auth_views.PasswordResetDoneView.as_view(),
-         name ='password_reset_done'),
+         name='password_reset_done'),
 
     path('reset/<uidb64>/<token>',
          auth_views.PasswordResetConfirmView.as_view(),
-         name ='password_reset_confirm'),
+         name='password_reset_confirm'),
 
     path('reset_password_complete/',
          auth_views.PasswordResetCompleteView.as_view(),
-         name ='password_reset_complete'),
+         name='password_reset_complete'),
 
 ]

--- a/saskatoon/sitebase/views.py
+++ b/saskatoon/sitebase/views.py
@@ -45,7 +45,7 @@ class Index(TemplateView):
                 return redirect('onboarding-person-update', user.person.pk)
 
             if user.has_temporary_password:
-                return redirect('change_password')
+                return redirect('change-password')
 
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
Clicking on `reset-password` button in community list view was still redirecing to django built-in view in admin. This PR clarifies routes and reverse_urls

----------
## Type of change:
- [x] Bug fix (change which fixes an issue).
- [ ] New feature (change which adds functionality).
- [ ] Changes to models (requires making migrations).
- [ ] Documentation change.
----------