### PR TITLE
feat: harvest form single date selection

### DIFF
--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -551,11 +551,14 @@ class HarvestForm(forms.ModelForm):
     )
 
     start_date = forms.DateTimeField(
-        input_formats=['%d/%m/%Y %H:%M', '%d/%m/%Y %H:%M:%S'],
+        label=_('Date/Start time'),
+        input_formats=['%d/%m/%Y %H:%M'],
         required=True
     )
+
     end_date = forms.DateTimeField(
-        input_formats=['%d/%m/%Y %H:%M', '%d/%m/%Y %H:%M:%S'],
+        label=_('End time'),
+        input_formats=['%H:%M'],
         required=True
     )
 
@@ -577,14 +580,18 @@ class HarvestForm(forms.ModelForm):
         return pickleader
 
     def clean_end_date(self):
-        """Check if harvest end_date is after start_date"""
-        start_date = self.cleaned_data['start_date']
-        end_date = self.cleaned_data['end_date']
-        if end_date <= start_date:
+        """Derive end date from start date in order to enforce a single date for harvests without changing model."""
+        start = self.cleaned_data['start_date']
+        end = self.cleaned_data['end_date']
+
+        start_dt = start
+        end_dt = dt.combine(start.date(), end.time(), tzinfo=start.tzinfo)
+
+        if end_dt <= start_dt:
             raise forms.ValidationError(
-                _('End date/time must be after start date/time')
+                _('End time must be after start time')
             )
-        return end_date
+        return end_dt
 
 
 

--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -551,7 +551,7 @@ class HarvestForm(forms.ModelForm):
     )
 
     start_date = forms.DateTimeField(
-        label=_('Date/Start time'),
+        label=_('Start date/time'),
         input_formats=['%d/%m/%Y %H:%M'],
         required=True
     )

--- a/saskatoon/sitebase/templates/app/base/scripts.html
+++ b/saskatoon/sitebase/templates/app/base/scripts.html
@@ -96,7 +96,8 @@
      });
 
      $("#id_end_date").datetimepicker({
-         format: 'd/m/Y H:i',
+         format: 'H:i',
+         datepicker: false,
      });
 
      $("#id_publication_date").datetimepicker({


### PR DESCRIPTION
Changes `HarvestForm` to only allow setting the date with `start_date` and deriving the date for `end_date` from there.

End time is still open to change and is validated to be after start as it did before.

Fixes #419

---

## Type of change:

- [ ] Bug fix (change which fixes an issue).
- [x] New feature (change which adds functionality).
- [ ] Changes to models (requires making migrations).
- [ ] Documentation change.

---

## What's Changed:

- end_date only checks time and derives date from start
- modify jquery datetimepicker format to match new input formats

---

## Screenshots:

---

## Affected URLs:

e.g. `127.0.0.1:8000/harvest/update/<int:pk>`

---

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
