### PR TITLE
feat: equipment point list page

### DIFF
--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -207,7 +207,7 @@ class BeneficiaryViewset(LoginRequiredMixin, viewsets.ModelViewSet):
     filterset_class = OrganizationFilter
 
     def retrieve(self, request, format='html', pk=None):
-        self.template_name = 'app/detail_views/beneficiary/view.html'
+        self.template_name = 'app/detail_views/organization/view.html'
 
         pk = self.get_object().pk
         response = super(BeneficiaryViewset, self).retrieve(request, pk=pk)
@@ -216,8 +216,8 @@ class BeneficiaryViewset(LoginRequiredMixin, viewsets.ModelViewSet):
             return response
 
         # default request format is html:
-        return Response({'beneficiary': response.data,
-                         # 'similar': get_similar_properties(self.get_object())
+        return Response({'organization': response.data,
+                         'data': Equipment.objects.filter(pk=pk)
                          })
 
     def list(self, request, *args, **kwargs):

--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -261,7 +261,7 @@ class EquipmentPointViewset(LoginRequiredMixin, viewsets.ModelViewSet):
         )
 
     def list(self, request, *args, **kwargs):
-        self.template_name = "app/list_views/EquipmentPoint/view.html"
+        self.template_name = "app/list_views/equipment-point/view.html"
         response = super(EquipmentPointViewset, self).list(request, *args, **kwargs)
         if request.accepted_renderer.format == "json":
             return response

--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -12,7 +12,7 @@ from harvest.forms import (RequestForm, RFPManageForm, CommentForm, HarvestYield
 from harvest.models import (HARVESTS_STATUS_CHOICES, Equipment, Harvest, HarvestYield, Property,
                             RequestForParticipation, Comment, TreeType)
 from harvest.serializers import (HarvestListSerializer, HarvestSerializer, PropertyListSerializer, PropertySerializer, EquipmentSerializer,
-                                 CommunitySerializer, BeneficiarySerializer,
+                                 CommunitySerializer, OrganizationSerializer,
                                  RequestForParticipationSerializer)
 from harvest.utils import get_similar_properties
 from member.models import AuthUser, Organization, Neighborhood, Person
@@ -202,7 +202,7 @@ class BeneficiaryViewset(LoginRequiredMixin, viewsets.ModelViewSet):
 
     permission_classes = [IsPickLeaderOrCoreOrAdmin]
     queryset = Organization.objects.all().order_by('-actor_id')
-    serializer_class = BeneficiarySerializer
+    serializer_class = OrganizationSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = OrganizationFilter
 
@@ -232,6 +232,50 @@ class BeneficiaryViewset(LoginRequiredMixin, viewsets.ModelViewSet):
                                  'title': _("New Organization")
                                  }
                          })
+
+
+class EquipmentPointViewset(LoginRequiredMixin, viewsets.ModelViewSet):
+    """EquipmentPoint viewset"""
+
+    permission_classes = [IsPickLeaderOrCoreOrAdmin]
+    queryset = Organization.objects.all().order_by("-actor_id")
+    serializer_class = OrganizationSerializer
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = OrganizationFilter
+
+    def retrieve(self, request, format="html", pk=None):
+        self.template_name = "app/detail_views/organization/view.html"
+
+        pk = self.get_object().pk
+        response = super(EquipmentPointViewset, self).retrieve(request, pk=pk)
+
+        if format == "json":
+            return response
+
+        # default request format is html:
+        return Response(
+            {
+                "organization": response.data,
+                "data": Equipment.objects.filter(owner_id=pk),
+            }
+        )
+
+    def list(self, request, *args, **kwargs):
+        self.template_name = "app/list_views/EquipmentPoint/view.html"
+        response = super(EquipmentPointViewset, self).list(request, *args, **kwargs)
+        if request.accepted_renderer.format == "json":
+            return response
+        # default request format is html:
+        return Response(
+            {
+                "data": response.data,
+                "filter": get_filter_context(self),
+                "new": {
+                    "url": reverse_lazy("organization-create"),
+                    "title": _("New Organization"),
+                },
+            }
+        )
 
 
 class CommunityViewset(LoginRequiredMixin, viewsets.ModelViewSet):

--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -228,7 +228,7 @@ class BeneficiaryViewset(LoginRequiredMixin, viewsets.ModelViewSet):
         # default request format is html:
         return Response({'data': response.data,
                          'filter': get_filter_context(self),
-                         'new': {'url': reverse_lazy('beneficiary-create'),
+                         'new': {'url': reverse_lazy('organization-create'),
                                  'title': _("New Organization")
                                  }
                          })

--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -205,9 +205,23 @@ class BeneficiaryViewset(LoginRequiredMixin, viewsets.ModelViewSet):
     serializer_class = BeneficiarySerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = OrganizationFilter
-    template_name = 'app/list_views/beneficiary/view.html'
+
+    def retrieve(self, request, format='html', pk=None):
+        self.template_name = 'app/detail_views/beneficiary/view.html'
+
+        pk = self.get_object().pk
+        response = super(BeneficiaryViewset, self).retrieve(request, pk=pk)
+
+        if format == 'json':
+            return response
+
+        # default request format is html:
+        return Response({'beneficiary': response.data,
+                         # 'similar': get_similar_properties(self.get_object())
+                         })
 
     def list(self, request, *args, **kwargs):
+        self.template_name = 'app/list_views/beneficiary/view.html'
         response = super(BeneficiaryViewset, self).list(request, *args, **kwargs)
         if request.accepted_renderer.format == 'json':
             return response

--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -217,7 +217,7 @@ class BeneficiaryViewset(LoginRequiredMixin, viewsets.ModelViewSet):
 
         # default request format is html:
         return Response({'organization': response.data,
-                         'data': Equipment.objects.filter(pk=pk)
+                         'data': Equipment.objects.filter(owner_id=pk)
                          })
 
     def list(self, request, *args, **kwargs):

--- a/saskatoon/harvest/filters.py
+++ b/saskatoon/harvest/filters.py
@@ -181,7 +181,11 @@ class OrganizationFilter(filters.FilterSet):
 
     class Meta:
         model = Organization
-        fields = ['neighborhood', 'is_beneficiary']
+        fields = [
+            'neighborhood',
+            'is_beneficiary',
+            'is_equipment_point',
+        ]
 
     neighborhood = filters.ModelChoiceFilter(
         queryset=Neighborhood.objects.all(),

--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -624,4 +624,9 @@ class EquipmentForm(forms.ModelForm):
             ),
         }
 
-        fields = '__all__'
+        fields = (
+            'owner',
+            'type',
+            'description',
+            'count',
+        )

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -55,7 +55,7 @@ class EquipmentSerializer(serializers.ModelSerializer):
         fields = ['type', 'count']
 
 
-class BeneficiarySerializer(serializers.ModelSerializer):
+class OrganizationSerializer(serializers.ModelSerializer):
     contact_person = PersonSerializer(many=False, read_only=True)
     neighborhood = NeighborhoodSerializer(many=False, read_only=True)
     equipment = EquipmentSerializer(many=True, read_only=True)
@@ -78,7 +78,7 @@ class BeneficiarySerializer(serializers.ModelSerializer):
 
 class ActorSerializer(serializers.ModelSerializer):
     person = PersonSerializer(source='get_person', many=False, read_only=True)
-    organization = BeneficiarySerializer(source='get_organization', many=False, read_only=True)
+    organization = OrganizationSerializer(source='get_organization', many=False, read_only=True)
 
     class Meta:
         model = Actor

--- a/saskatoon/harvest/urls.py
+++ b/saskatoon/harvest/urls.py
@@ -10,6 +10,7 @@ router.register('harvest', api.HarvestViewset, 'harvest')
 router.register('property', api.PropertyViewset, 'property')
 router.register('equipment', api.EquipmentViewset, 'equipment')
 router.register('beneficiary', api.BeneficiaryViewset, 'beneficiary')
+router.register('equipment-point', api.EquipmentPointViewset, 'equipment-point')
 router.register('community', api.CommunityViewset, 'community')
 router.register('participation', api.RequestForParticipationViewset, 'participation')
 

--- a/saskatoon/harvest/views.py
+++ b/saskatoon/harvest/views.py
@@ -30,8 +30,8 @@ class EquipmentCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateVi
     def get_organization(self):
         """If creating new harvest from Organization page"""
         try:
-            pid = self.request.GET['pid']
-            return Organization.objects.get(actor_id=pid)
+            aid = self.request.GET['aid']
+            return Organization.objects.get(actor_id=aid)
         except (KeyError, Organization.DoesNotExist):
             return None
 

--- a/saskatoon/harvest/views.py
+++ b/saskatoon/harvest/views.py
@@ -16,6 +16,7 @@ from harvest.forms import (PropertyForm, PropertyCreateForm, PublicPropertyForm,
 from harvest.models import (Equipment, Harvest, HarvestYield, Property,
                             RequestForParticipation, Comment)
 from member.permissions import is_pickleader_or_core
+from member.models import Organization
 
 
 class EquipmentCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateView):
@@ -25,6 +26,22 @@ class EquipmentCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateVi
     template_name = 'app/forms/model_form.html'
     success_url = reverse_lazy('equipment-list')
     success_message = _("Equipment created successfully!")
+
+    def get_organization(self):
+        """If creating new harvest from Organization page"""
+        try:
+            pid = self.request.GET['pid']
+            return Organization.objects.get(actor_id=pid)
+        except (KeyError, Organization.DoesNotExist):
+            return None
+
+    def get_initial(self):
+        initial = {}
+        _organization = self.get_organization()
+        if _organization:
+            initial['owner'] = _organization
+        return initial
+
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/saskatoon/member/urls.py
+++ b/saskatoon/member/urls.py
@@ -8,9 +8,9 @@ urlpatterns = [
          views.PersonCreateView.as_view(),
          name='person-create'),
 
-    path('beneficiary/create/',
+    path('organization/create/',
          views.OrganizationCreateView.as_view(),
-         name='beneficiary-create'),
+         name='organization-create'),
 
     # UPDATE VIEWS
     path('person/update/<int:pk>/',
@@ -21,9 +21,9 @@ urlpatterns = [
          views.OnboardingPersonUpdateView.as_view(),
          name='onboarding-person-update'),
 
-    path('beneficiary/update/<int:pk>/',
+    path('organization/update/<int:pk>/',
          views.OrganizationUpdateView.as_view(),
-         name='beneficiary-update'),
+         name='organization-update'),
 
     path('user/change_password/',
          views.PasswordChangeView.as_view(),

--- a/saskatoon/sitebase/templates/app/base/menu.html
+++ b/saskatoon/sitebase/templates/app/base/menu.html
@@ -22,7 +22,7 @@
                                 <a href="{% url 'property-list' %}?is_active=true&authorized=2">{% translate "Properties" %}</a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'beneficiary-list' %}active{% endif %}">
-                                <a href="{% url 'beneficiary-list' %}">{% translate "Beneficiaries" %}</a>
+                                <a href="{% url 'beneficiary-list' %}?is_beneficiary=true">{% translate "Beneficiaries" %}</a>
                             </li>
                             <li class="{% if request.resolver_match.url_name == 'community-list' %}active{% endif %}">
                                 <!--TODO <a href="{% url 'community-list' %}">{% translate "Community" %}</a> -->
@@ -62,7 +62,7 @@
                         <a href="{% url 'property-list' %}?is_active=true&authorized=2"><i class="glyphicon glyphicon-tree-deciduous"></i> {% translate "Properties" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'beneficiary-list' %}active{% endif %}">
-                        <a href="{% url 'beneficiary-list' %}"><i class="fa fa-gift"></i> {% translate "Beneficiaries" %}</a>
+                        <a href="{% url 'beneficiary-list' %}?is_beneficiary=true"><i class="fa fa-gift"></i> {% translate "Beneficiaries" %}</a>
                     </li>
                     <li class="{% if request.resolver_match.url_name == 'community-list' %}active{% endif %}">
                         <!--TODO <a href="{% url 'community-list' %}"><i class="fa fa-users"></i> {% translate "Community" %}</a> -->

--- a/saskatoon/sitebase/templates/app/base/menu.html
+++ b/saskatoon/sitebase/templates/app/base/menu.html
@@ -28,8 +28,8 @@
                                 <!--TODO <a href="{% url 'community-list' %}">{% translate "Community" %}</a> -->
                                 <a href="{% url 'community-list' %}?groups=3">{% translate "Community" %}</a>
                             </li>
-                            <li class="{% if request.resolver_match.url_name == 'equipment-list' %}active{% endif %}">
-                                <a href="{% url 'equipment-list' %}">{% translate "Equipment" %}</a>
+                            <li class="{% if request.resolver_match.url_name == 'equipment-point-list' %}active{% endif %}">
+                                <a href="{% url 'equipment-point-list' %}?is_equipment_point=true">{% translate "Equipment Point" %}</a>
                             </li>
                             {% if user|is_core_or_admin %}
                             <li class="{% if request.resolver_match.url_name == 'statistics' %}active{% endif %}">
@@ -68,8 +68,8 @@
                         <!--TODO <a href="{% url 'community-list' %}"><i class="fa fa-users"></i> {% translate "Community" %}</a> -->
                         <a href="{% url 'community-list' %}?groups=3"><i class="fa fa-users"></i> {% translate "Community" %}</a>
                     </li>
-                    <li class="{% if request.resolver_match.url_name == 'equipment-list' %}active{% endif %}">
-                        <a href="{% url 'equipment-list' %}"><i class="fa fa-scissors"></i> {% translate "Equipment" %}</a>
+                    <li class="{% if request.resolver_match.url_name == 'equipment-point-list' %}active{% endif %}">
+                        <a href="{% url 'equipment-point-list' %}?is_equipment_point=true"><i class="fa fa-scissors"></i> {% translate "Equipment Points" %}</a>
                     </li>
                     {% if user|is_core_or_admin %}
                     <li class="{% if request.resolver_match.url_name == 'statistics' %}active{% endif %}">

--- a/saskatoon/sitebase/templates/app/detail_views/organization/about.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/about.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% load static %}
+{% load get_fruit_name_icon %}
+<div class="search-engine-int">
+  <div class="contact-hd search-hd-eg">
+    <h2>{% translate 'Description' %}</h2>
+    <hr>
+  </div>
+  <div>
+    <p>{{ organization.description }}</p>
+  </div>
+</div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/about.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/about.html
@@ -1,29 +1,9 @@
 {% load i18n %}
 {% load static %}
-{% load get_fruit_name_icon %}
-<div class="search-engine-int">
+<div class="search-engine-int" style="flex: 100%;">
   <div class="contact-hd search-hd-eg">
     <h2>{% translate 'About' %}</h2>
     <hr />
-    <div style="display: flex; flex-flow: column; gap: 1rem;">
-      <div>
-        <p>{{ organization.description }}</p>
-      </div>
-
-      {% if organization.is_beneficiary and organization.beneficiary_description %}
-      <div>
-        <h4>{% translate 'Beneficiary Description' %}</h4>
-        <p>{{ organization.beneficiary_description }}</p>
-        {% endif %}
-      </div>
-
-      <div>
-        {% if organization.is_equipment_point and organization.equipment_description %}
-        <h4>{% translate 'Equipment Description' %}</h4>
-        <p>{{ organization.equipment_description }}</p>
-        {% endif %}
-      </div>
-    </div>
-
+    <p>{{ organization.description }}</p>
   </div>
 </div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/about.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/about.html
@@ -3,10 +3,27 @@
 {% load get_fruit_name_icon %}
 <div class="search-engine-int">
   <div class="contact-hd search-hd-eg">
-    <h2>{% translate 'Description' %}</h2>
-    <hr>
-  </div>
-  <div>
-    <p>{{ organization.description }}</p>
+    <h2>{% translate 'About' %}</h2>
+    <hr />
+    <div style="display: flex; flex-flow: column; gap: 1rem;">
+      <div>
+        <p>{{ organization.description }}</p>
+      </div>
+
+      {% if organization.is_beneficiary and organization.beneficiary_description %}
+      <div>
+        <h4>{% translate 'Beneficiary Description' %}</h4>
+        <p>{{ organization.beneficiary_description }}</p>
+        {% endif %}
+      </div>
+
+      <div>
+        {% if organization.is_equipment_point and organization.equipment_description %}
+        <h4>{% translate 'Equipment Description' %}</h4>
+        <p>{{ organization.equipment_description }}</p>
+        {% endif %}
+      </div>
+    </div>
+
   </div>
 </div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/address.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/address.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% load static %}
+<div class="search-engine-int sm-res-mg-t-30 tb-res-mg-t-30 tb-res-mg-t-0">
+  <div class="contact-hd search-hd-eg">
+    <h2>{% translate 'Address' %}</h2>
+    <hr />
+    <div>
+      <p>{{ organization.address }}</p>
+      <!-- <p>{{ organization.neighborhood.name }}</p> -->
+    </div>
+  </div>
+</div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/address.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/address.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load static %}
-<div class="search-engine-int sm-res-mg-t-30 tb-res-mg-t-30 tb-res-mg-t-0">
+<div class="search-engine-int mg-t-30 sm-res-mg-t-30 tb-res-mg-t-30  tb-res-ds-n dk-res-ds">
   <div class="contact-hd search-hd-eg">
     <h2>{% translate 'Address' %}</h2>
     <hr />

--- a/saskatoon/sitebase/templates/app/detail_views/organization/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/breadcomb.html
@@ -24,7 +24,7 @@
                         <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
                             <div class="breadcomb-report">
                                 {% if perms.member.change_organization %}
-                                    <a href="{% url 'beneficiary-update' organization.actor_id %}">
+                                    <a href="{% url 'organization-update' organization.actor_id %}">
                                         <button title="Edit Organization" class="btn">
                                             {% trans "Edit Organization" %}</button>
                                     </a>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/breadcomb.html
@@ -1,0 +1,39 @@
+{% load i18n %}
+{% load static %}
+<div class="breadcomb-area">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
+                <div class="breadcomb-list">
+                    <div class="row">
+                        <div class="col-lg-10 col-md-10 col-sm-10 col-xs-12">
+                            <div class="breadcomb-wp">
+                                <div class="breadcomb-icon">
+                                    <i class="fa fa-gift"></i>
+                                </div>
+                                <div class="breadcomb-ctn">
+                                    <h1>
+                                        {{ organization.civil_name }}
+                                    </h1>
+                                    <h2>
+                                        {{ organization.neighborhood.name }}
+                                    </h2>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
+                            <div class="breadcomb-report">
+                                {% if perms.member.change_organization %}
+                                    <a href="{% url 'beneficiary-update' organization.actor_id %}">
+                                        <button title="Edit Organization" class="btn">
+                                            {% trans "Edit Organization" %}</button>
+                                    </a>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/contact.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/contact.html
@@ -1,0 +1,89 @@
+{% load i18n %}
+{% load static %}
+<div class="search-engine-int sm-res-mg-t-30 tb-res-mg-t-30 tb-res-ds-n dk-res-ds">
+  <div class="contact-hd search-hd-eg">
+    <h2>{% translate 'Contact' %}</h2>
+    <hr />
+  </div>
+
+  <table class="table">
+    <tbody>
+      {% if organization.contact_person %}
+
+      <tr>
+        <td>{% trans "Contact person" %}</td>
+        <td class="text-right">
+          <h5>
+            {{ organization.contact_person.name }}
+          </h5>
+        </td>
+      </tr>
+
+      {% if organization.contact_person_role %}
+      <tr>
+        <td>{% trans "Role" %}</td>
+        <td class="text-right">
+          <h5>
+            {{ organization.contact_person_role }}
+          </h5>
+        </td>
+      </tr>
+      {% endif %}
+
+      {% if organization.contact_person.phone %}
+      <tr>
+        <td>{% trans "Phone" %}</td>
+        <td class="text-right">
+          <h5>
+            {{ organization.contact_person.phone }}
+          </h5>
+        </td>
+      </tr>
+      {% endif %}
+
+      {% if organization.contact_person.email %}
+      <tr>
+        <td>{% trans "Email" %}</td>
+        <td class="text-right">
+          <h5>
+            {{ organization.contact_person.email }}
+          </h5>
+        </td>
+      </tr>
+      {% endif %}
+
+      {% if organization.contact_person.language %}
+      <tr>
+        <td>{% trans "Language" %}</td>
+        <td class="text-right">
+          <h5>{{ organization.contact_person.language }}</h5>
+        </td>
+      </tr>
+      {% endif %}
+
+      {% if organization.contact_person.comments %}
+      <tr>
+        <td>{% trans "Comments" %}</td>
+        <td class="text-right">
+          <p>{{ organization.contact_person.comments }}</p>
+        </td>
+      </tr>
+      {% endif %}
+
+      {% endif %}
+
+      {% if organization.phone %}
+      <tr>
+        <td>{% trans "Organization phone" %}</td>
+        <td class="text-right">
+          <h5>
+            {{ organization.phone }}
+          </h5>
+        </td>
+      </tr>
+      {% endif %}
+
+
+    </tbody>
+  </table>
+</div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/equipment_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/equipment_row.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+{% load static %}
+<tr>
+  <td>{{ equipment.id }}
+    {% if perms.harvest.change_equipment %}
+    <a href="{% url 'equipment-update' equipment.id %}">
+      &nbsp; <i class="fa fa-pencil"></i></a>
+    {% endif %}
+  </td>
+  <td>
+    {% if LANG == "fr" %}
+    {{ equipment.type.name_fr }}
+    {% else %}
+    {{ equipment.type.name_en }}
+    {% endif %}
+  </td>
+  <td>
+    {{equipment.count}}
+  </td>
+  <td>
+    <span>{{ equipment.description }}
+    </span><br>
+  </td>
+  <td>
+  </td>
+</tr>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
@@ -8,7 +8,7 @@
           <div class="table-responsive">
             <div>
               <h4> {% trans Equipment %} </h4>
-              {% if perms.harvest.add_equipment and organization.is_equipment_point %}
+              {% if perms.harvest.add_equipment %}
               <a href="{% url 'equipment-create' %}?pid={{ organization.actor_id }}">
                 <button title="New Equipment" class="btn btn-success notika-btn-success waves-effect">
                   <i class="fa fa-plus"></i>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
@@ -9,7 +9,7 @@
             <div>
               <h4> {% trans Equipment %} </h4>
               {% if perms.harvest.add_equipment and organization.is_equipment_point %}
-              <a href="{% url 'equipment-create' %}?pid={{ property.id }}">
+              <a href="{% url 'equipment-create' %}?pid={{ organization.actor_id }}">
                 <button title="New Equipment" class="btn btn-success notika-btn-success waves-effect">
                   <i class="fa fa-plus"></i>
                   {% trans "New Equipment" %}

--- a/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
@@ -21,10 +21,10 @@
             <table class="table table-striped" id="data-table-basic">
               <thead>
                 <tr>
-                  <th class="col-xs-1">#</th>
-                  <th class="col-xs-2">{% trans "Equipment Type" %}</th>
-                  <th class="col-xs-1">{% trans "Count" %}</th>
-                  <th class="col-xs-4">{% trans "Description" %}</th>
+                  <th style="width: 10%">#</th>
+                  <th style="width: 20%">{% trans "Equipment Type" %}</th>
+                  <th style="width: 10%">{% trans "Count" %}</th>
+                  <th style="width: 60%">{% trans "Description" %}</th>
                 </tr>
               </thead>
               <tbody>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
@@ -1,0 +1,41 @@
+{% load i18n %}
+{% load static %}
+<div class="search-engine-area mg-t-30">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
+        <div class="data-table-list">
+          <div class="table-responsive">
+            <h4> {% trans Equipment %}
+              {% if perms.harvest.add_equipment and organization.is_equipment_point %}
+              <a href="{% url 'equipment-create' %}?pid={{ property.id }}">
+                <button title="New Equipment" class="btn btn-success notika-btn-success waves-effect">
+                  <i class="fa fa-plus"></i>
+                  {% trans "New Equipment" %}
+                </button>
+              </a>
+              {% endif %}
+            </h4>
+            <table class="table table-striped" id="data-table-basic">
+              <thead>
+                <tr>
+                  <th class="col-xs-1">#</th>
+                  <th class="col-xs-2">{% trans "Equipment Type" %}</th>
+                  <th class="col-xs-1">{% trans "Count" %}</th>
+                  <th class="col-xs-4">{% trans "Description" %}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for equipment in data %}
+
+                {% include 'app/detail_views/organization/equipment_row.html' %}
+
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
@@ -6,7 +6,8 @@
       <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
         <div class="data-table-list">
           <div class="table-responsive">
-            <h4> {% trans Equipment %}
+            <div>
+              <h4> {% trans Equipment %} </h4>
               {% if perms.harvest.add_equipment and organization.is_equipment_point %}
               <a href="{% url 'equipment-create' %}?pid={{ property.id }}">
                 <button title="New Equipment" class="btn btn-success notika-btn-success waves-effect">
@@ -15,7 +16,8 @@
                 </button>
               </a>
               {% endif %}
-            </h4>
+            </div>
+            <br>
             <table class="table table-striped" id="data-table-basic">
               <thead>
                 <tr>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/features.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/features.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+{% load static %}
+<div class="search-engine-int sm-res-mg-t-30 tb-res-mg-t-30 tb-res-mg-t-0">
+
+    <div class="contact-hd search-hd-eg">
+        <h2>{% translate 'Features' %}</h2>
+    </div>
+
+
+    <div class="search-eg-table">
+        <table class="table">
+            <tbody>
+              {% if organization.is_equipment_point %}
+                  <tr><td>
+                      <i class="notika-icon notika-checked"></i>
+                      {% trans "Is an equipment point" %}
+                  </td></tr>
+              {% else %}
+                  <tr><td>
+                      <i class="notika-icon notika-close"></i>
+                      {% trans "Is not an equipment point" %}
+                  </td></tr>
+              {% endif %}
+            </tbody>
+        </table>
+    </div>
+
+</div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/features.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/features.html
@@ -2,27 +2,41 @@
 {% load static %}
 <div class="search-engine-int sm-res-mg-t-30 tb-res-mg-t-30 tb-res-mg-t-0">
 
-    <div class="contact-hd search-hd-eg">
-        <h2>{% translate 'Features' %}</h2>
-    </div>
+  <div class="contact-hd search-hd-eg">
+    <h2>{% translate 'Features' %}</h2>
+    <hr />
+  </div>
 
 
-    <div class="search-eg-table">
-        <table class="table">
-            <tbody>
-              {% if organization.is_equipment_point %}
-                  <tr><td>
-                      <i class="notika-icon notika-checked"></i>
-                      {% trans "Is an equipment point" %}
-                  </td></tr>
-              {% else %}
-                  <tr><td>
-                      <i class="notika-icon notika-close"></i>
-                      {% trans "Is not an equipment point" %}
-                  </td></tr>
-              {% endif %}
-            </tbody>
-        </table>
-    </div>
+  <div class="search-eg-table">
+    <table class="table">
+      <tbody>
+        <tr>
+          <td>
+            {% if organization.is_beneficiary %}
+            <i class="notika-icon notika-checked"></i>
+            {% trans "Is a beneficiary" %}
+            {% else %}
+            <i class="notika-icon notika-close"></i>
+            {% trans "Is not beneficiary" %}
+            {% endif %}
+          </td>
+        </tr>
+
+        <tr>
+          <td>
+            {% if organization.is_equipment_point %}
+            <i class="notika-icon notika-checked"></i>
+            {% trans "Is an equipment point" %}
+            {% else %}
+            <i class="notika-icon notika-close"></i>
+            {% trans "Is not an equipment point" %}
+            {% endif %}
+          </td>
+        </tr>
+
+      </tbody>
+    </table>
+  </div>
 
 </div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/features.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/features.html
@@ -1,42 +1,29 @@
 {% load i18n %}
 {% load static %}
-<div class="search-engine-int sm-res-mg-t-30 tb-res-mg-t-30 tb-res-mg-t-0">
+<div class="search-engine-int mg-t-30 sm-res-mg-t-30 tb-res-mg-t-30">
+  <div style="display: flex; flex-flow: row wrap;">
+    <div class="search-engine-int" style="flex: 50%">
+      <h4>
+        <span>{% translate 'Beneficiary' %}</span>
+        {% if organization.is_beneficiary %}
+        <i class="notika-icon notika-checked"></i>
+        {% else %}
+        <i class="notika-icon notika-close"></i>
+        {% endif %}
+      </h4>
+      <p>{{ organization.beneficiary_description }}</p>
+    </div>
 
-  <div class="contact-hd search-hd-eg">
-    <h2>{% translate 'Features' %}</h2>
-    <hr />
+    <div class="search-engine-int" style="flex: 50%;">
+      <h4>
+        <span>{% translate 'Equipment Point' %}</span>
+        {% if organization.is_equipment_point %}
+        <i class="notika-icon notika-checked"></i>
+        {% else %}
+        <i class="notika-icon notika-close"></i>
+        {% endif %}
+      </h4>
+      <p>{{ organization.equipment_description }}</p>
+    </div>
   </div>
-
-
-  <div class="search-eg-table">
-    <table class="table">
-      <tbody>
-        <tr>
-          <td>
-            {% if organization.is_beneficiary %}
-            <i class="notika-icon notika-checked"></i>
-            {% trans "Is a beneficiary" %}
-            {% else %}
-            <i class="notika-icon notika-close"></i>
-            {% trans "Is not beneficiary" %}
-            {% endif %}
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            {% if organization.is_equipment_point %}
-            <i class="notika-icon notika-checked"></i>
-            {% trans "Is an equipment point" %}
-            {% else %}
-            <i class="notika-icon notika-close"></i>
-            {% trans "Is not an equipment point" %}
-            {% endif %}
-          </td>
-        </tr>
-
-      </tbody>
-    </table>
-  </div>
-
 </div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/view.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/view.html
@@ -23,6 +23,7 @@
 </div>
 
 {% if organization.is_equipment_point %}
+<!-- FIXME: table does not render some elements surrounding the data e.g. search bar -->
 {% include 'app/detail_views/organization/equipment_table.html' %}
 {% endif %}
 

--- a/saskatoon/sitebase/templates/app/detail_views/organization/view.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/view.html
@@ -1,0 +1,31 @@
+{% extends 'app/base/view.html' %}
+{% load i18n %}
+{% load static %}
+{% load auth_users %}
+
+{% block content %}
+
+{% include 'app/detail_views/organization/breadcomb.html' %}
+
+<div class="search-engine-area mg-t-30">
+  <div class="container">
+    <div class="row">
+      <div class="col-lg-4 col-md-6 col-sm-12 col-xs-12">
+        {% include 'app/detail_views/organization/about.html' %}
+      </div>
+      <div class="col-lg-4 col-md-6 col-sm-12 col-xs-12">
+        {% include 'app/detail_views/organization/contact.html' %}
+      </div>
+      <div class="col-lg-4 col-md-6 col-sm-12 col-xs-12">
+        {% include 'app/detail_views/organization/address.html' %}
+        {% include 'app/detail_views/organization/features.html' %}
+      </div>
+    </div>
+  </div>
+</div>
+
+{% if organization.is_equipment_point %}
+{% include 'app/detail_views/organization/equipment_table.html' %}
+{% endif %}
+
+{% endblock content %}

--- a/saskatoon/sitebase/templates/app/detail_views/organization/view.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/view.html
@@ -11,14 +11,12 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-4 col-md-6 col-sm-12 col-xs-12">
-        {% include 'app/detail_views/organization/about.html' %}
-      </div>
-      <div class="col-lg-4 col-md-6 col-sm-12 col-xs-12">
         {% include 'app/detail_views/organization/contact.html' %}
-      </div>
-      <div class="col-lg-4 col-md-6 col-sm-12 col-xs-12">
         {% include 'app/detail_views/organization/address.html' %}
         {% include 'app/detail_views/organization/features.html' %}
+      </div>
+      <div class="col-lg-8 col-md-6 col-sm-12 col-xs-12">
+        {% include 'app/detail_views/organization/about.html' %}
       </div>
     </div>
   </div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/view.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/view.html
@@ -13,10 +13,10 @@
       <div class="col-lg-4 col-md-6 col-sm-12 col-xs-12">
         {% include 'app/detail_views/organization/contact.html' %}
         {% include 'app/detail_views/organization/address.html' %}
-        {% include 'app/detail_views/organization/features.html' %}
       </div>
       <div class="col-lg-8 col-md-6 col-sm-12 col-xs-12">
         {% include 'app/detail_views/organization/about.html' %}
+        {% include 'app/detail_views/organization/features.html' %}
       </div>
     </div>
   </div>

--- a/saskatoon/sitebase/templates/app/list_views/beneficiary/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/beneficiary/data_row.html
@@ -54,8 +54,6 @@
         </a>
     </td>
 
-    <td>{{ org.description }}</td>
-
     <td>
         {% if org.is_beneficiary %}
             <i class="fa fa-check text-success"></i>

--- a/saskatoon/sitebase/templates/app/list_views/beneficiary/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/beneficiary/data_row.html
@@ -25,7 +25,7 @@
             {% endif %}
             {% if perms.member.change_actor %}
                 &nbsp;
-                <small><a href="{% url 'beneficiary-update' org.actor_id %}" title="edit">
+                <small><a href="{% url 'organization-update' org.actor_id %}" title="edit">
                     <i class="fa fa-pencil"></i>
                 </a></small>
             {% endif %}

--- a/saskatoon/sitebase/templates/app/list_views/beneficiary/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/beneficiary/data_row.html
@@ -17,7 +17,9 @@
     </td>
     <td>
         <span>
-            <b>{{ org.civil_name }}</b>
+            <b>
+              <a href="{% url 'beneficiary-detail' org.actor_id %}">{{ org.civil_name }}</a> 
+            </b>
             {% if org.is_beneficiary %}
                 <i class="fa fa-gift"></i>
             {% endif %}

--- a/saskatoon/sitebase/templates/app/list_views/beneficiary/view.html
+++ b/saskatoon/sitebase/templates/app/list_views/beneficiary/view.html
@@ -11,7 +11,6 @@
             <th class="col-xs-1">#</th>
             <th class="col-xs-2">{% trans "Organization" %}</th>
             <th class="col-xs-1">{% trans "Contact" %}</th>
-            <th class="col-xs-4">{% trans "Description" %}</th>
             <th class="col-xs-1">{% trans "Beneficiary" %}</th>
             <th class="col-xs-1">{% trans "Equipment" %}</th>
             <th class="col-xs-2">{% trans "Neighborhood" %}</th>

--- a/saskatoon/sitebase/templates/app/list_views/community/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/community/data_row.html
@@ -67,7 +67,7 @@
             <p><a href="{% url 'property-detail' property.id %}">{{ property.short_address }}</a></p>
         {% endfor %}
         {% for org in user.person.organizations_as_contact %}
-            <a href="{% url 'beneficiary-update' org.pk %}">{{ org }}</a>
+            <a href="{% url 'organization-update' org.pk %}">{{ org }}</a>
         {% endfor %}
     </td>
     <td>{{ user.person.neighborhood.name }}</td>

--- a/saskatoon/sitebase/templates/app/list_views/equipment-point/beneficiary-modal.html
+++ b/saskatoon/sitebase/templates/app/list_views/equipment-point/beneficiary-modal.html
@@ -1,0 +1,46 @@
+{% load static %}
+{% load i18n %}
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        $('#beneficiary-modal').on('show.bs.modal', function (e) {
+            $('#beneficiary-modal-title').html($(e.relatedTarget).data('title'));
+            $('#beneficiary-modal-description').html($(e.relatedTarget).data('description'));
+
+            let info = $(e.relatedTarget).data('info');
+            const inventory = $(e.relatedTarget).data('inventory')
+            if (inventory) {
+                const inventoryList = inventory.split("&;").map(i => `<li>${i}</li>`).join("");
+                info += `<ul style="list-style-type:circle; padding-left:2em;">${inventoryList}</ul>`;
+            }
+            $('#beneficiary-modal-info').html(info);
+        });
+    });
+</script>
+
+<div id="beneficiary-modal" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="beneficiary-modal" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header" style="border-bottom: 0 none">
+                <span id="beneficiary-modal-title" class="h3 modal-title"></span>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+
+            <div class="modal-body">
+                <div id="beneficiary-modal-info" class="text-info"></div>
+
+                <div class="text-info">
+                    <ul id="beneficiary-modal-inventory" style="list-style-type:circle; padding-left:2em;"></ul>
+                </div>
+
+                <hr>
+                <blockquote>
+                    <p id="beneficiary-modal-description"></p>
+                </blockquote>
+                <hr>
+            </div>
+        </div>
+    </div>
+</div>

--- a/saskatoon/sitebase/templates/app/list_views/equipment-point/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/equipment-point/data_row.html
@@ -1,0 +1,99 @@
+{% load i18n %}
+{% load static %}
+{% get_current_language as LANG %}
+
+<tr>
+    <td>
+        {% if perms.member.delete_actor %}
+            <small>
+                <a href="{% url 'admin:member_actor_delete' org.actor_id %}"
+                onclick="return confirm('{% trans "Are you really sure you want to delete this actor?" %}');">
+                    <i class="fa fa-trash text-danger"></i>
+                </a>
+            &nbsp;
+            </small>
+        {% endif %}
+        {{ org.actor_id }}
+    </td>
+    <td>
+        <span>
+            <b>
+              <a href="{% url 'beneficiary-detail' org.actor_id %}">{{ org.civil_name }}</a> 
+            </b>
+            {% if org.is_beneficiary %}
+                <i class="fa fa-gift"></i>
+            {% endif %}
+            {% if perms.member.change_actor %}
+                &nbsp;
+                <small><a href="{% url 'organization-update' org.actor_id %}" title="edit">
+                    <i class="fa fa-pencil"></i>
+                </a></small>
+            {% endif %}
+        </span>
+        <br> <i class="fa fa-phone text-muted"></i>&nbsp; {{ org.phone }}
+        {% if org.short_address %}
+            <br> <i class="fa fa-envelope-o text-muted"></i> {{ org.short_address }}
+        {% endif %}
+    </td>
+
+    <td>
+        <b>{{ org.contact_person.name }}</b>
+        {% if org.contact_person and perms.member.change_person %}
+            &nbsp;
+            <small><a href="{% url 'person-update' org.contact_person.actor_id %}" title="edit">
+                <i class="fa fa-pencil"></i>
+            </a></small>
+        {% endif %}
+        {% if org.contact_person.phone %}
+            <br> <i class="fa fa-mobile text-muted"></i>&nbsp;
+            {{ org.contact_person.phone }}
+        {% endif %}
+        <br>
+        <a href="mailto:{{org.contact_person.email}}">
+            {{ org.contact_person.email }}
+        </a>
+    </td>
+
+    <td>
+        {% if org.is_beneficiary %}
+            <i class="fa fa-check text-success"></i>
+            {% if org.beneficiary_description %}
+                &nbsp; <a data-toggle="modal"
+                       title="fruit donation"
+                       data-info="{% trans 'This organization accepts fruit donations' %}"
+                       data-title="{{org.civil_name}}"
+                       data-description="{{org.beneficiary_description}}"
+                       href="#beneficiary-modal">
+                    {% trans "info" %}
+                </a>
+            {% endif %}
+        {% else %}
+            <i class="fa fa-times text-danger"></i>
+        {% endif %}
+    </td>
+    <td>
+        {% if org.is_equipment_point %}
+            <i class="fa fa-check text-success"></i>
+            {% if org.equipment_description %}
+                &nbsp; <a data-toggle="modal"
+                       title="equipment"
+                    {% if LANG == "fr" %}
+                       data-info="Équipment disponible à cette organisation:"
+                       data-inventory="{{org.inventory.fr}}"
+                    {% else %}
+                       data-info="This organization has the following equipment:"
+                       data-inventory="{{org.inventory.en}}"
+                    {% endif %}
+                       data-title="{{org.civil_name}}"
+                       data-description="{{org.equipment_description}}"
+                       href="#beneficiary-modal">
+                    {% trans "info" %}
+                </a>
+            {% endif %}
+        {% else %}
+            <i class="fa fa-times text-danger"></i>
+    {% endif %}
+    </td>
+
+    <td>{{ org.neighborhood.name }}</td>
+</tr>

--- a/saskatoon/sitebase/templates/app/list_views/equipment-point/view.html
+++ b/saskatoon/sitebase/templates/app/list_views/equipment-point/view.html
@@ -1,0 +1,25 @@
+{% extends 'app/list_views/base.html' %}
+{% load i18n %}
+{% load static %}
+
+{% block table %}
+
+    {% include 'app/list_views/beneficiary/beneficiary-modal.html' %}
+
+    <thead>
+        <tr>
+            <th class="col-xs-1">#</th>
+            <th class="col-xs-2">{% trans "Organization" %}</th>
+            <th class="col-xs-1">{% trans "Contact" %}</th>
+            <th class="col-xs-1">{% trans "Beneficiary" %}</th>
+            <th class="col-xs-1">{% trans "Equipment" %}</th>
+            <th class="col-xs-2">{% trans "Neighborhood" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for org in data %}
+            {% include 'app/list_views/beneficiary/data_row.html' %}
+        {% endfor %}
+    </tbody>
+
+{% endblock table %}

--- a/saskatoon/sitebase/templates/app/list_views/equipment/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/equipment/data_row.html
@@ -39,7 +39,7 @@
                 </a>
                 {% if perms.member.change_actor %}
                 &nbsp;
-                <small><a href="{% url 'beneficiary-update' org.actor_id %}" title="edit">
+                <small><a href="{% url 'organization-update' org.actor_id %}" title="edit">
                         <i class="fa fa-pencil"></i>
                     </a></small>
                 {% endif %}

--- a/saskatoon/sitebase/templates/app/list_views/equipment/data_table.html
+++ b/saskatoon/sitebase/templates/app/list_views/equipment/data_table.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+{% load static %}
+
+{% block table %}
+
+    {% include 'app/list_views/beneficiary/beneficiary-modal.html' %}
+
+    <thead>
+        <tr>
+            <th class="col-xs-1">#</th>
+            <th class="col-xs-1">{% trans "Equipment Type" %}</th>
+            <th class="col-xs-1">{% trans "Count" %}</th>
+            <th class="col-xs-2">{% trans "Description" %}</th>
+            <th class="col-xs-1">{% trans "Owner" %}</th>
+            <th class="col-xs-1">{% trans "Shared" %}</th>
+            <th class="col-xs-1">{% trans "Contact" %}</th>
+            <th class="col-xs-1">{% trans "Neighborhood" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for equipment in data %}
+
+            {% include 'app/list_views/equipment/data_row.html' %}
+
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock table %}


### PR DESCRIPTION
Converts existing `Equipment` list page into an `Equipment Point` page.
Some changes to `Beneficiary` list page to synchronise UI.

Partially fixes #415

_TODO:_

- [ ] add description column
- [ ] find suitable icon for "More info" button for descriptions
- filters:
  - [ ] equipment type
  - [ ] neighbourhood

---

## Type of change:

- [ ] Bug fix (change which fixes an issue).
- [x] New feature (change which adds functionality).
- [ ] Changes to models (requires making migrations).
- [ ] Documentation change.

---

## What's Changed:

- Convert equipment list page into an equipment points list page

---

## Screenshots:

---

## Affected URLs:

- `127.0.0.1:8000/equipment/`
- `127.0.0.1:8000/equipment-point/`

---

## Checklist:

- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
