### PR TITLE
chore: clean up detail views serializers

### DIFF
--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -11,7 +11,7 @@ from harvest.filters import (EquipmentPointFilter, HarvestFilter, PropertyFilter
 from harvest.models import (Equipment, Harvest, HarvestYield, Property,
                             RequestForParticipation, TreeType)
 from harvest.serializers import (HarvestListSerializer, HarvestDetailSerializer,
-                                 HarvestSerializer, PropertyListSerializer,
+                                 PropertyListSerializer,
                                  PropertySerializer, EquipmentSerializer,
                                  CommunitySerializer, OrganizationSerializer,
                                  RequestForParticipationSerializer)
@@ -45,7 +45,8 @@ class HarvestViewset(LoginRequiredMixin, viewsets.ModelViewSet):
 
     permission_classes = [IsPickLeaderOrCoreOrAdmin]
     queryset = Harvest.objects.all().order_by('-id')
-    serializer_class = HarvestSerializer
+    serializer_class = HarvestDetailSerializer
+    template_name = 'app/detail_views/harvest/view.html'
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = HarvestFilter
     filterset_fields = ('pick_leader',
@@ -56,19 +57,13 @@ class HarvestViewset(LoginRequiredMixin, viewsets.ModelViewSet):
                         'status',
                         'season')
 
-    # Harvest detail
-    def retrieve(self, request, *args, **kwargs):
-        self.template_name = 'app/detail_views/harvest/view.html'
-        self.serializer_class = HarvestDetailSerializer
-        return super(HarvestViewset, self).retrieve(request, *args, **kwargs)
-
     def list(self, request, *args, **kwargs):
         self.template_name = 'app/list_views/harvest/view.html'
         self.serializer_class = HarvestListSerializer
-
         response = super(HarvestViewset, self).list(request, *args, **kwargs)
         if renderer_format_needs_json_response(request):
             return Response(response.data)
+        # default request format is html:
         return Response(
             {
                 "data": response.data["results"],
@@ -85,9 +80,6 @@ class HarvestViewset(LoginRequiredMixin, viewsets.ModelViewSet):
                 },
             }
         )
-
-    def update(request, *args, **kwargs):
-        pass
 
 
 class PropertyViewset(LoginRequiredMixin, viewsets.ModelViewSet):

--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -187,31 +187,16 @@ class OrganizationViewset(LoginRequiredMixin, viewsets.ModelViewSet):
 
     permission_classes = [IsPickLeaderOrCoreOrAdmin]
     queryset = Organization.objects.all().order_by('-actor_id')
+    template_name = 'app/detail_views/organization/view.html'
     serializer_class = OrganizationSerializer
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = OrganizationFilter
-
-    def retrieve(self, request, format='html', pk=None):
-        """Organization detail view -  shared by beneficiaries and equipment points."""
-        self.template_name = 'app/detail_views/organization/view.html'
-
-        pk = self.get_object().pk
-        response = super(OrganizationViewset, self).retrieve(request, pk=pk)
-
-        if format == 'json':
-            return response
-
-        # default request format is html:
-        return Response({
-            'organization': response.data,
-            'data': Equipment.objects.filter(owner_id=pk)
-        })
 
     def list(self, request, *args, **kwargs):
         """Organization list view - accessible via the Beneficiaries menu button."""
         self.template_name = 'app/list_views/organization/view.html'
         response = super(OrganizationViewset, self).list(request, *args, **kwargs)
-        if request.accepted_renderer.format == 'json':
+        if renderer_format_needs_json_response(request):
             return response
         # default request format is html:
         return Response({
@@ -243,13 +228,13 @@ class EquipmentPointListView(LoginRequiredMixin, generics.ListAPIView):
     template_name = 'app/list_views/equipment_point/view.html'
 
     def list(self, request, *args, **kwargs):
-        response = super(EquipmentPointListView, self).list(request, *args, **kwargs)
+        response = super().list(request, *args, **kwargs)
 
-        if request.accepted_renderer.format == 'json':
+        if renderer_format_needs_json_response(request):
             return response
 
         context = {
-            'data': response.data,
+            'data': response.data["results"],
             'filter': get_filter_context(self, 'equipment-point'),
         }
 

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -73,55 +73,6 @@ class RequestForParticipationSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class EquipmentTypeSerializer(serializers.ModelSerializer):
-    name = serializers.SerializerMethodField()
-
-    class Meta:
-        model = EquipmentType
-        fields = ['name', 'name_fr', 'name_en']
-
-    def get_name(self, type):
-        return type.name_fr
-
-
-class EquipmentSerializer(serializers.ModelSerializer):
-    type = EquipmentTypeSerializer(many=False, read_only=True)
-
-    class Meta:
-        model = Equipment
-        fields = ['type', 'count']
-
-
-class OrganizationSerializer(serializers.ModelSerializer):
-    contact_person = PersonSerializer(many=False, read_only=True)
-    neighborhood = NeighborhoodSerializer(many=False, read_only=True)
-    equipment = EquipmentSerializer(many=True, read_only=True)
-    inventory = serializers.SerializerMethodField()
-
-    class Meta:
-        model = Organization
-        fields = ['actor_id', 'civil_name', 'contact_person',
-                  'phone', 'short_address', 'address', 'neighborhood',
-                  'is_beneficiary', 'beneficiary_description',
-                  'is_equipment_point', 'equipment_description',
-                  'description', 'equipment', 'inventory']
-
-    def get_inventory(self, org):
-        return dict([
-            (lang, "&;".join([e.inventory(lang) for e in org.equipment.all()]))
-            for lang in ['fr', 'en']
-        ])
-
-
-class ActorSerializer(serializers.ModelSerializer):
-    person = PersonSerializer(source='get_person', many=False, read_only=True)
-    organization = OrganizationSerializer(source='get_organization', many=False, read_only=True)
-
-    class Meta:
-        model = Actor
-        fields = '__all__'
-
-
 class CitySerializer(serializers.ModelSerializer):
     class Meta:
         model = City
@@ -253,32 +204,6 @@ class PropertyListSerializer(PropertySerializer):
         ]
 
 
-class EquipmentPropertySerializer(PropertyListSerializer):
-    class Meta(PropertyListSerializer.Meta):
-        fields = [
-            'id',
-            'title',
-            'neighborhood',
-            'owner'
-        ]
-
-
-class EquipmentTypeSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = EquipmentType
-        fields = '__all__'
-
-
-class EquipmentSerializer(serializers.ModelSerializer):
-    property = EquipmentPropertySerializer(many=False, read_only=True)
-    type = EquipmentTypeSerializer(many=False, read_only=True)
-    owner = ActorSerializer(many=False, read_only=True)
-
-    class Meta:
-        model = Equipment
-        fields = '__all__'
-
-
 class PickLeaderSerializer(serializers.ModelSerializer):
     class Meta:
         model = AuthUser
@@ -406,3 +331,63 @@ class CommunitySerializer(serializers.ModelSerializer):
 
     def get_role_codes(self, instance):
         return [g.name for g in instance.role_groups]
+
+
+class EquipmentPropertySerializer(PropertyListSerializer):
+    class Meta(PropertyListSerializer.Meta):
+        fields = [
+            'id',
+            'title',
+            'neighborhood',
+            'owner'
+        ]
+
+
+class EquipmentTypeSerializer(serializers.ModelSerializer):
+    name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = EquipmentType
+        fields = ['name', 'name_fr', 'name_en']
+
+    def get_name(self, type):
+        return type.name_fr
+
+
+class EquipmentSerializer(serializers.ModelSerializer):
+    property = EquipmentPropertySerializer(many=False, read_only=True)
+    type = EquipmentTypeSerializer(many=False, read_only=True)
+
+    class Meta:
+        model = Equipment
+        fields = '__all__'
+
+
+class OrganizationSerializer(serializers.ModelSerializer):
+    contact_person = PersonSerializer(many=False, read_only=True)
+    neighborhood = NeighborhoodSerializer(many=False, read_only=True)
+    equipment = EquipmentSerializer(many=True, read_only=True)
+    inventory = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Organization
+        fields = ['actor_id', 'civil_name', 'contact_person',
+                  'phone', 'short_address', 'address', 'neighborhood',
+                  'is_beneficiary', 'beneficiary_description',
+                  'is_equipment_point', 'equipment_description',
+                  'description', 'equipment', 'inventory']
+
+    def get_inventory(self, org):
+        return dict([
+            (lang, "&;".join([e.inventory(lang) for e in org.equipment.all()]))
+            for lang in ['fr', 'en']
+        ])
+
+
+class ActorSerializer(serializers.ModelSerializer):
+    person = PersonSerializer(source='get_person', many=False, read_only=True)
+    organization = OrganizationSerializer(source='get_organization', many=False, read_only=True)
+
+    class Meta:
+        model = Actor
+        fields = '__all__'

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -342,6 +342,7 @@ class HarvestTreeTypeSerializer(serializers.ModelSerializer):
 
 class HarvestBeneficiarySerializer(serializers.ModelSerializer):
     class Meta:
+        model = Organization
         fields = ['actor_id', 'civil_name']
 
 

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -4,6 +4,7 @@ from member.models import (Actor, Neighborhood, AuthUser, Person,
                            Organization, City, State, Country)
 from harvest.models import (Comment, Harvest, HarvestYield, Property, Equipment,
                             EquipmentType, RequestForParticipation, TreeType)
+from harvest.utils import similar_properties
 
 
 class NeighborhoodSerializer(serializers.ModelSerializer):
@@ -201,6 +202,7 @@ class PropertySerializer(serializers.ModelSerializer):
     owner = serializers.SerializerMethodField()
     pending_contact_name = serializers.ReadOnlyField()
     owner_type = serializers.SerializerMethodField()
+    similar_properties = serializers.SerializerMethodField()
 
     class Meta:
         model = Property
@@ -216,6 +218,9 @@ class PropertySerializer(serializers.ModelSerializer):
 
     def get_owner_type(self, obj):
         return OwnerTypeSerializer(obj.owner).data
+
+    def get_similar_properties(self, obj):
+        return similar_properties(obj)
 
 
 class PropertyListHarvestSerializer(PropertyHarvestSerializer):

--- a/saskatoon/harvest/utils.py
+++ b/saskatoon/harvest/utils.py
@@ -5,7 +5,7 @@ from harvest.models import Property
 logger = getLogger('saskatoon')
 
 
-def get_similar_properties(pending_property):
+def similar_properties(pending_property):
     """Look for potential property/owner duplicates"""
 
     p = pending_property
@@ -39,6 +39,5 @@ def get_similar_properties(pending_property):
         return Property.objects.filter(query).exclude(id=p.id).distinct()
 
     except Exception as _e:
-        logger.warning("Could not find similar properties to <%s> (%s: %s)",
-                     p, type(_e), str(_e))
+        logger.warning("Could not find similar properties to <%s> (%s: %s)", p, type(_e), str(_e))
         return Property.objects.none()

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/data_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/data_table.html
@@ -11,12 +11,12 @@
                                 <div class="basic-tb-hd">
                                     <h2>
                                         {% trans "Pickers requests" %}
-                                        ({% if harvest.is_open_to_requests %}{% trans "OPEN" %}{% else %}{% trans "CLOSED" %}{% endif %})
+                                        ({% if is_open_to_requests %}{% trans "OPEN" %}{% else %}{% trans "CLOSED" %}{% endif %})
                                     </h2>
                                 </div>
                             </div>
                                 <div class="col-xs-6">
-                                    <a href="{% url 'rfp-create' %}?hid={{ harvest.id }}"
+                                    <a href="{% url 'rfp-create' %}?hid={{ id }}"
                                             class="btn btn-success notika-btn-success waves-effect"
                                         style="float: right">
                                         <i class="fa fa-plus"></i> {% trans "New request" %}

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
@@ -10,16 +10,16 @@
                 <div class="wb-traffic-inner notika-shadow sm-res-mg-t-30 tb-res-mg-t-30">
                     <div class="website-traffic-ctn">
                         <p>{% translate 'Harvest status' %}</p>
-                        {% if harvest.pick_leader is None or harvest.pick_leader.id != request.user.id %}
-                        <h2>{{ harvest.status }}</h2>
+                        {% if pick_leader is None or pick_leader.id != request.user.id %}
+                        <h2>{{ status }}</h2>
                         {% else %}
                         <div class="dropdown">
                             <button
-                            {% if harvest.status == 'Succeeded' %}
+                            {% if status == 'Succeeded' %}
                             class="btn btn-success dropdown-toggle"
-                            {% elif harvest.status == 'Cancelled' %}
+                            {% elif status == 'Cancelled' %}
                             class="btn btn-danger dropdown-toggle"
-                            {% elif harvest.status == 'Ready' %}
+                            {% elif status == 'Ready' %}
                             class="btn btn-primary dropdown-toggle"
                             {% else %}
                             class="btn btn-warning dropdown-toggle"
@@ -30,7 +30,7 @@
                             >
                                 <p style="font-size: 1.5em; color:white;">
                                     <strong>
-                                        {{ harvest.status }}
+                                        {{ status }}
                                         <span class="caret"></span>
                                     </strong>
                                 </p>
@@ -43,7 +43,7 @@
                                 {% for status_option in status_options %}
                                 <li role="presentation">
                                     <a
-                                    href="{% url 'harvest-status-change' harvest.id %}?status={{ status_option }}"
+                                    href="{% url 'harvest-status-change' id %}?status={{ status_option }}"
                                     role="menuitem"
                                     tabindex="-1"
                                     >
@@ -91,13 +91,13 @@
                 <div class="wb-traffic-inner notika-shadow sm-res-mg-t-30 tb-res-mg-t-30 dk-res-mg-t-30">
                     <div class="website-traffic-ctn">
                         <p>{% trans "Pick leader" %}</p>
-                        {% if harvest.pick_leader is None %}
+                        {% if pick_leader is None %}
                         <div class="row">
                             <div class="col-lg-8">
                                 <h2>{% trans "Missing" %}</h2>
                             </div>
                             <div class="col-lg-4 breadcomb-report">
-                                <a href="{% url 'harvest-adopt' harvest.id %}">
+                                <a href="{% url 'harvest-adopt' id %}">
                                     <button
                                     data-placement="left"
                                     title="Adopt it!"
@@ -108,13 +108,13 @@
                                 </a>
                             </div>
                         </div>
-                        {% elif harvest.pick_leader.id == request.user.id %}
+                        {% elif pick_leader.id == request.user.id %}
                         <div class="row">
                             <div class="col-lg-7">
-                                <h2>{{ harvest.pick_leader.name }}</h2>
+                                <h2>{{ pick_leader.name }}</h2>
                             </div>
                             <div class="col-lg-5 breadcomb-report">
-                                <a href="{% url 'harvest-leave' harvest.id %}">
+                                <a href="{% url 'harvest-leave' id %}">
                                     <button
                                     data-placement="left"
                                     title="Leave it!"
@@ -126,7 +126,7 @@
                             </div>
                         </div>
                         {% else %}
-                        <h2>{{ harvest.pick_leader.name }}</h2>
+                        <h2>{{ pick_leader.name }}</h2>
                         {% endif %}
                     </div>
                 </div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/about.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/about.html
@@ -4,6 +4,6 @@
   <div class="contact-hd search-hd-eg">
     <h2>{% translate 'About' %}</h2>
     <hr />
-    <p>{{ organization.description }}</p>
+    <p>{{ description }}</p>
   </div>
 </div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/address.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/address.html
@@ -5,8 +5,8 @@
     <h2>{% translate 'Address' %}</h2>
     <hr />
     <div>
-      <p>{{ organization.address }}</p>
-      <!-- <p>{{ organization.neighborhood.name }}</p> -->
+      <p>{{ address }}</p>
+      <!-- <p>{{ neighborhood.name }}</p> -->
     </div>
   </div>
 </div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/breadcomb.html
@@ -13,10 +13,10 @@
                                 </div>
                                 <div class="breadcomb-ctn">
                                     <h1>
-                                        {{ organization.civil_name }}
+                                        {{ civil_name }}
                                     </h1>
                                     <h2>
-                                        {{ organization.neighborhood.name }}
+                                        {{ neighborhood.name }}
                                     </h2>
                                 </div>
                             </div>
@@ -24,7 +24,7 @@
                         <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
                             <div class="breadcomb-report">
                                 {% if perms.member.change_organization %}
-                                    <a href="{% url 'organization-update' organization.actor_id %}">
+                                    <a href="{% url 'organization-update' actor_id %}">
                                         <button title="Edit Organization" class="btn">
                                             {% trans "Edit Organization" %}</button>
                                     </a>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/contact.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/contact.html
@@ -8,81 +8,80 @@
 
   <table class="table">
     <tbody>
-      {% if organization.contact_person %}
+      {% if contact_person %}
 
       <tr>
         <td>{% trans "Contact person" %}</td>
         <td class="text-right">
           <h5>
-            {{ organization.contact_person.name }}
+            {{ contact_person.name }}
           </h5>
         </td>
       </tr>
 
-      {% if organization.contact_person_role %}
+      {% if contact_person_role %}
       <tr>
         <td>{% trans "Role" %}</td>
         <td class="text-right">
           <h5>
-            {{ organization.contact_person_role }}
+            {{ contact_person_role }}
           </h5>
         </td>
       </tr>
       {% endif %}
 
-      {% if organization.contact_person.phone %}
+      {% if contact_person.phone %}
       <tr>
         <td>{% trans "Phone" %}</td>
         <td class="text-right">
           <h5>
-            {{ organization.contact_person.phone }}
+            {{ contact_person.phone }}
           </h5>
         </td>
       </tr>
       {% endif %}
 
-      {% if organization.contact_person.email %}
+      {% if contact_person.email %}
       <tr>
         <td>{% trans "Email" %}</td>
         <td class="text-right">
           <h5>
-            {{ organization.contact_person.email }}
+            {{ contact_person.email }}
           </h5>
         </td>
       </tr>
       {% endif %}
 
-      {% if organization.contact_person.language %}
+      {% if contact_person.language %}
       <tr>
         <td>{% trans "Language" %}</td>
         <td class="text-right">
-          <h5>{{ organization.contact_person.language }}</h5>
+          <h5>{{ contact_person.language }}</h5>
         </td>
       </tr>
       {% endif %}
 
-      {% if organization.contact_person.comments %}
+      {% if contact_person.comments %}
       <tr>
         <td>{% trans "Comments" %}</td>
         <td class="text-right">
-          <p>{{ organization.contact_person.comments }}</p>
+          <p>{{ contact_person.comments }}</p>
         </td>
       </tr>
       {% endif %}
 
       {% endif %}
 
-      {% if organization.phone %}
+      {% if phone %}
       <tr>
         <td>{% trans "Organization phone" %}</td>
         <td class="text-right">
           <h5>
-            {{ organization.phone }}
+            {{ phone }}
           </h5>
         </td>
       </tr>
       {% endif %}
-
 
     </tbody>
   </table>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/equipment_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/equipment_row.html
@@ -1,24 +1,24 @@
 {% load i18n %}
 {% load static %}
 <tr>
-  <td>{{ equipment.id }}
+  <td>{{ item.id }}
     {% if perms.harvest.change_equipment %}
-    <a href="{% url 'equipment-update' equipment.id %}">
+    <a href="{% url 'equipment-update' item.id %}">
       &nbsp; <i class="fa fa-pencil"></i></a>
     {% endif %}
   </td>
   <td>
     {% if LANG == "fr" %}
-    {{ equipment.type.name_fr }}
+    {{ item.type.name_fr }}
     {% else %}
-    {{ equipment.type.name_en }}
+    {{ item.type.name_en }}
     {% endif %}
   </td>
   <td>
-    {{equipment.count}}
+    {{item.count}}
   </td>
   <td>
-    <span>{{ equipment.description }}
+    <span>{{ item.description }}
     </span><br>
   </td>
   <td>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
@@ -9,7 +9,7 @@
             <div>
               <h4> {% trans Equipment %} </h4>
               {% if perms.harvest.add_equipment %}
-              <a href="{% url 'equipment-create' %}?aid={{ organization.actor_id }}">
+              <a href="{% url 'equipment-create' %}?aid={{ actor_id }}">
                 <button title="New Equipment" class="btn btn-success notika-btn-success waves-effect">
                   <i class="fa fa-plus"></i>
                   {% trans "New Equipment" %}
@@ -28,7 +28,7 @@
                 </tr>
               </thead>
               <tbody>
-                {% for equipment in data %}
+                {% for item in equipment %}
 
                 {% include 'app/detail_views/organization/equipment_row.html' %}
 

--- a/saskatoon/sitebase/templates/app/detail_views/organization/features.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/features.html
@@ -5,25 +5,25 @@
     <div class="search-engine-int" style="flex: 50%">
       <h4>
         <span>{% translate 'Beneficiary' %}</span>
-        {% if organization.is_beneficiary %}
+        {% if is_beneficiary %}
         <i class="notika-icon notika-checked"></i>
         {% else %}
         <i class="notika-icon notika-close"></i>
         {% endif %}
       </h4>
-      <p>{{ organization.beneficiary_description }}</p>
+      <p>{{ beneficiary_description }}</p>
     </div>
 
     <div class="search-engine-int" style="flex: 50%;">
       <h4>
         <span>{% translate 'Equipment Point' %}</span>
-        {% if organization.is_equipment_point %}
+        {% if is_equipment_point %}
         <i class="notika-icon notika-checked"></i>
         {% else %}
         <i class="notika-icon notika-close"></i>
         {% endif %}
       </h4>
-      <p>{{ organization.equipment_description }}</p>
+      <p>{{ equipment_description }}</p>
     </div>
   </div>
 </div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/view.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/view.html
@@ -22,9 +22,9 @@
   </div>
 </div>
 
-{% if organization.is_equipment_point %}
+{% if is_equipment_point %}
 <!-- FIXME: table does not render some elements surrounding the data e.g. search bar -->
-{% include 'app/detail_views/organization/equipment_table.html' %}
+    {% include 'app/detail_views/organization/equipment_table.html' %}
 {% endif %}
 
 {% endblock content %}

--- a/saskatoon/sitebase/templates/app/detail_views/property/about.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/about.html
@@ -7,13 +7,13 @@
         <hr>
         <div class="tpgp-ele-tx">
             <h2>{% translate 'Address' %}</h2>
-            <p>{{ property.address }}</p>
-            <p>{{ property.neighborhood.name }}</p>
+            <p>{{ address }}</p>
+            <p>{{ neighborhood.name }}</p>
             <br>
 
             <h2>{% translate 'Available tree' %}(s)</h2>
             <ul>
-                {% for tree in property.trees %}
+                {% for tree in trees %}
                 <li>- {{ tree.name }} {{ tree.fruit_name|get_fruit_name_icon }}</li>
                 {% endfor %}
             </ul>
@@ -21,13 +21,13 @@
 
             <h2>{% translate 'Accessibility' %}</h2>
             <ul>
-                <li>- {{ property.trees_location|default:"" }}</li>
-                <li>- {{ property.trees_accessibility|default:"" }}</li>
+                <li>- {{ trees_location|default:"" }}</li>
+                <li>- {{ trees_accessibility|default:"" }}</li>
             </ul>
             <br>
 
             <h2>{% translate 'Additional information' %}</h2>
-            <p>{{ property.additional_info|default:"" }}</p>
+            <p>{{ additional_info|default:"" }}</p>
         </div>
     </div>
 </div>

--- a/saskatoon/sitebase/templates/app/detail_views/property/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/breadcomb.html
@@ -13,20 +13,20 @@
                                 </div>
                                 <div class="breadcomb-ctn">
                                     <h1>
-                                    {% if property.owner %}
-                                        {{ property.title }}
-                                    {% elif property.pending_contact_name %}
-                                        {{ property.pending_contact_name }}
-                                        at {{ property.address }}
+                                    {% if owner %}
+                                        {{ title }}
+                                    {% elif pending_contact_name %}
+                                        {{ pending_contact_name }}
+                                        at {{ address }}
                                     {% else %}
-                                        {{ property.address }}
+                                        {{ address }}
                                     {% endif %}
                                     </h1>
-                                    {% if property.pending %}
+                                    {% if pending %}
                                         <h4>** {% translate 'PENDING' %} **</h4>
-                                    {% elif property.last_succeeded_harvest_date %}
+                                    {% elif last_succeeded_harvest_date %}
                                         <p>{% trans "Last succeeded harvest"  %}
-                                            on {{ property.last_succeeded_harvest_date|date }}
+                                            on {{ last_succeeded_harvest_date|date }}
                                         </p>
                                     {% else %}
                                         <p>{% translate 'No succeeded harvest on this property so far' %}</p>
@@ -37,7 +37,7 @@
                         <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
                             <div class="breadcomb-report">
                                 {% if perms.harvest.change_property %}
-                                    <a href="{% url 'property-update' property.id %}">
+                                    <a href="{% url 'property-update' id %}">
                                         <button title="Edit Property" class="btn">
                                             {% trans "Edit Property" %}</button>
                                     </a>

--- a/saskatoon/sitebase/templates/app/detail_views/property/contact.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/contact.html
@@ -3,13 +3,13 @@
 <div class="search-engine-int sm-res-mg-t-30 tb-res-mg-t-30 tb-res-ds-n dk-res-ds">
 
     <div class="contact-hd search-hd-eg">
-        {% if property.owner %}
+        {% if owner %}
             <h2>{% trans "Owner" %}
-            {% if property.owner_type.is_organization %}
+            {% if owner_type.is_organization %}
                 <small>{% trans "(Organization)" %}</small>
-            {% elif property.owner_type.is_person and perms.member.change_person %}
+            {% elif owner_type.is_person and perms.member.change_person %}
                 &nbsp;
-                <small><a href="{% url 'person-update' property.owner.pk %}?pid={{property.id}}">
+                <small><a href="{% url 'person-update' owner.pk %}?pid={{id}}">
                         <i class="fa fa-pencil"></i> {% trans "edit" %}
                 </a></small>
             {% endif %}
@@ -18,7 +18,7 @@
             <h2>{% trans "Unregistered owner" %}
             {% if perms.member.add_person %}
                 &nbsp;
-                <small><a href="{% url 'person-create' %}?pid={{property.id}}">
+                <small><a href="{% url 'person-create' %}?pid={{id}}">
                         <i class="fa fa-pencil"></i> {% translate 'register' %}
                 </a></small>
             {% endif %}
@@ -28,20 +28,20 @@
     </div>
 
     <p class="lead">
-    {% if property.owner %}
-        {{ property.owner.name }}
+    {% if owner %}
+        {{ owner.name }}
     {% else %}
-        {{ property.pending_contact_first_name }} {{ property.pending_contact_family_name }}
+        {{ pending_contact_first_name }} {{ pending_contact_family_name }}
     {% endif %}
     </p>
 
     <table class="table">
         <tbody>
-        {% if property.owner_type.is_organization %}
+        {% if owner_type.is_organization %}
             <tr>
                 <td>{% trans "Contact" %}</td>
                 <td class="text-right">
-                    <h5>{{ property.owner.contact }}</h5>
+                    <h5>{{ owner.contact }}</h5>
                 </td>
             </tr>
         {% endif %}
@@ -50,10 +50,10 @@
             <td>{% trans "Phone" %}</td>
             <td class="text-right">
                 <h5>
-                {% if property.owner %}
-                    {{ property.owner.phone }}
+                {% if owner %}
+                    {{ owner.phone }}
                 {% else %}
-                    {{ property.pending_contact_phone }}
+                    {{ pending_contact_phone }}
                 {% endif %}
                 </h5>
             </td>
@@ -63,21 +63,21 @@
             <td>{% trans "Email" %}</td>
             <td class="text-right">
                 <h5>
-                {% if property.owner %}
-                    {{ property.owner.email }}
+                {% if owner %}
+                    {{ owner.email }}
                 {% else %}
-                    {{ property.pending_contact_email }}
+                    {{ pending_contact_email }}
                 {% endif %}
                 </h5>
             </td>
         </tr>
 
-        {% if property.owner %}
-            {% if property.owner.language %}
+        {% if owner %}
+            {% if owner.language %}
                 <tr>
                     <td>{% trans "Language" %}</td>
                     <td class="text-right">
-                        <h5>{{ property.owner.language }}</h5>
+                        <h5>{{ owner.language }}</h5>
                     </td>
                 </tr>
             {% endif %}
@@ -85,11 +85,11 @@
             <!-- TODO: preferred language -->
         {% endif %}
 
-        {% if property.owner.comments %}
+        {% if owner.comments %}
         <tr>
             <td>{% trans "Comments" %}</td>
             <td class="text-right">
-                <p>{{ property.owner.comments }}</p>
+                <p>{{ owner.comments }}</p>
             </td>
         </tr>
         {% endif %}

--- a/saskatoon/sitebase/templates/app/detail_views/property/features.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/features.html
@@ -9,9 +9,9 @@
     <div class="search-eg-table">
         <table class="table">
             <tbody>
-            {% if property.is_active %}
+            {% if is_active %}
 
-                {% if property.pending %}
+                {% if pending %}
                     <tr> <td class="text-right">
                             <b class="text-danger">
                                 {% trans "Pending validation" %}
@@ -19,7 +19,7 @@
                             <i class="notika-icon notika-close"></i>
                     </td></tr>
 
-                    {% if property.pending_recurring %}
+                    {% if pending_recurring %}
                         <tr><td class="text-right">
                             <b>
                                 {% trans "Has already been registered in the past" %}
@@ -41,14 +41,14 @@
                 {% endif %}
 
 
-                {% if property.authorized is None %}
+                {% if authorized is None %}
                     <tr><td class="text-right">
                         <b class="text-danger">
                             {% trans "Not yet authorized" %}
                         </b>
                         <i class="notika-icon notika-checked"></i>
                     </td></tr>
-                {% elif property.authorized %}
+                {% elif authorized %}
                     <tr><td class="text-right">
                         {% trans "Authorized for the current season" %}
                         <i class="notika-icon notika-checked"></i>
@@ -71,7 +71,7 @@
                 </td></tr>
             {% endif %}
 
-            {% if property.harvest_every_year %}
+            {% if harvest_every_year %}
                 <tr><td class="text-right">
                     {% trans "Produces fruits every year" %}
                     <i class="notika-icon notika-checked"></i>
@@ -83,9 +83,9 @@
                 </td></tr>
             {% endif %}
 
-            {% if property.avg_nb_required_pickers %}
+            {% if avg_nb_required_pickers %}
                 <tr><td class="text-right">
-                    {{ property.avg_nb_required_pickers }}
+                    {{ avg_nb_required_pickers }}
                     {% trans "picker(s) needed" %}
                     <i class="notika-icon notika-checked"></i>
                 </td></tr>
@@ -96,12 +96,12 @@
                 </td></tr>
             {% endif %}
 
-            {% if property.ladder_available %}
+            {% if ladder_available %}
                 <tr><td class="text-right">
                     {% trans "Ladder available" %}
                     <i class="notika-icon notika-checked"></i>
                 </td></tr>
-                {% if property.ladder_available_for_outside_picks %}
+                {% if ladder_available_for_outside_picks %}
                     <tr><td class="text-right">
                         {% trans "Ladder available for outside picks" %}
                         <i class="notika-icon notika-checked"></i>
@@ -114,7 +114,7 @@
                 </td></tr>
             {% endif %}
 
-            {% if property.public_access %}
+            {% if public_access %}
                 <tr><td class="text-right">
                     {% trans "Publicly accessible" %}
                     <i class="notika-icon notika-checked"></i>
@@ -126,7 +126,7 @@
                 </td></tr>
             {% endif %}
 
-            {% if property.neighbor_access %}
+            {% if neighbor_access %}
                 <tr><td class="text-right">
                     {% trans "Access to neighbors terrain" %}
                     <i class="notika-icon notika-checked"></i>
@@ -138,7 +138,7 @@
                 </td></tr>
             {% endif %}
 
-            {% if property.compost_bin %}
+            {% if compost_bin %}
                 <tr><td class="text-right">
                     {% trans "Compost bin closeby" %}
                     <i class="notika-icon notika-checked"></i>

--- a/saskatoon/sitebase/templates/app/detail_views/property/harvest_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/harvest_table.html
@@ -7,9 +7,9 @@
                 <div class="data-table-list">
                     <div class="table-responsive">
                         <h4> {% trans Harvests %}
-                            {% if perms.harvest.add_harvest and property.authorized %}
+                            {% if perms.harvest.add_harvest and authorized %}
                                 &nbsp;
-                                <a href="{% url 'harvest-create' %}?pid={{ property.id }}">
+                                <a href="{% url 'harvest-create' %}?pid={{ id }}">
                                     <button title="New harvest"
                                             class="btn btn-success notika-btn-success waves-effect">
                                         <i class="fa fa-plus"></i>
@@ -28,7 +28,7 @@
                                 <th style="width: 20%">{% trans "Date" %}</th>
                             </tr>
                             </thead>
-                            {% for harvest in property.harvests %}
+                            {% for harvest in harvests %}
 
                                 {% include 'app/detail_views/property/harvest_row.html' %}
 

--- a/saskatoon/sitebase/templates/app/detail_views/property/similar_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/similar_row.html
@@ -2,32 +2,32 @@
 {% load static %}
 
 <tr>
-    <td> {{property.id}} </td>
+    <td> {{id}} </td>
     <td>
-        <a href="{% url 'property-detail' property.pk %}">
+        <a href="{% url 'property-detail' pk %}">
             {{property}}
         </a>
     </td>
-    <td> {{ property.neighborhood }} </td>
+    <td> {{ neighborhood }} </td>
     <td> {% include 'app/list_views/property/status.html' %} </td>
 
-    {% if property.owner %}
+    {% if owner %}
         <td>
-            {{ property.owner }} &nbsp;
-            {% if property.owner.is_person and perms.member.change_person %}
-                <small><a href="{% url 'person-update' property.owner.pk %}" title="edit">
+            {{ owner }} &nbsp;
+            {% if owner.is_person and perms.member.change_person %}
+                <small><a href="{% url 'person-update' owner.pk %}" title="edit">
                         <i class="fa fa-pencil"></i>
                     </a></small>
             {% endif %}
         </td>
         <td>
-            {% if property.owner.is_person %}
-                {% with property.owner.person as po %}
+            {% if owner.is_person %}
+                {% with owner.person as po %}
                     <a href="mailto:{{po.email}}">{{ po.email }}</a> &nbsp;
                     {{ po.phone|default_if_none:"" }}
                 {% endwith %}
-            {% elif property.owner.is_organization %}
-                {% with property.owner.organization.contact_person as po %}
+            {% elif owner.is_organization %}
+                {% with owner.organization.contact_person as po %}
                     <a href="mailto:{{po.email}}">{{ po.email }}</a> &nbsp;
                     {{ po.phone|default_if_none:"" }}
                 {% endwith %}

--- a/saskatoon/sitebase/templates/app/detail_views/property/view.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/view.html
@@ -25,7 +25,7 @@
     </div>
 </div>
 
-{% if property.pending %}
+{% if pending %}
     {% include 'app/detail_views/property/similar_table.html' %}
 {% else %}
     {% include 'app/detail_views/property/harvest_table.html' %}


### PR DESCRIPTION
This PR simplifies detail views by falling back on the default `retrieve` method provided by Viewsets.
It also makes sure the whole data is being serialized and no extra content is passed to the templates.
