### PR TITLE
fix: picker serializer in fruit distribution dropdown

### DIFF
--- a/saskatoon/harvest/filters.py
+++ b/saskatoon/harvest/filters.py
@@ -261,4 +261,6 @@ class HarvestSeasonAdminFilter(SimpleListFilter):
         return SEASON_FILTER_CHOICES
 
     def queryset(self, request, queryset):
-        return queryset.filter(start_date__year=self.value())
+        if self.value():
+            return queryset.filter(start_date__year=self.value())
+        return queryset

--- a/saskatoon/harvest/models.py
+++ b/saskatoon/harvest/models.py
@@ -534,10 +534,6 @@ class Harvest(models.Model):
         tz = timezone.get_current_timezone()
         return self.end_date.astimezone(tz) if self.end_date else self.end_date
 
-    def get_pickers(self):
-        requests = RequestForParticipation.objects.filter(harvest=self, is_accepted=True)
-        return requests.values('picker_id', 'picker__first_name', 'picker__family_name')
-
     def get_unselected_pickers(self):
         """Volunteers who have been rejected or are waiting for approval"""
         requests = self.requests.exclude(Q(is_accepted=True) | Q(is_cancelled=True))

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -10,6 +10,7 @@ from member.serializers import (
     PersonRFPSerializer,
     PersonSerializer,
     PickLeaderSerializer,
+    PickerSerializer,
 )
 from harvest.models import (
     Comment,
@@ -168,9 +169,6 @@ class HarvestSerializer(serializers.ModelSerializer):
         model = Harvest
         fields = '__all__'
 
-    pickers = serializers.ReadOnlyField(
-        source='get_pickers'
-    )
     total_distribution = serializers.ReadOnlyField(
         source='get_total_distribution'
     )
@@ -194,11 +192,15 @@ class HarvestSerializer(serializers.ModelSerializer):
     requests = RequestForParticipationSerializer(many=True, read_only=True)
     harvestyield_set = HarvestYieldSerializer(many=True, read_only=True)
     comment = CommentSerializer(many=True, read_only=True)
+    pickers = serializers.SerializerMethodField()
     organizations = serializers.SerializerMethodField()
 
+    def get_pickers(self, obj):
+        rfps = RequestForParticipation.objects.filter(harvest=obj, is_accepted=True)
+        return PickerSerializer([rfp.picker for rfp in rfps], many=True).data
+
     def get_organizations(self, obj):
-        organizations = Organization.objects.filter(
-            is_beneficiary=True)
+        organizations = Organization.objects.filter(is_beneficiary=True)
         return OrganizationSerializer(organizations, many=True).data
 
 

--- a/saskatoon/harvest/views.py
+++ b/saskatoon/harvest/views.py
@@ -28,7 +28,7 @@ from harvest.models import (
     Property,
     RequestForParticipation,
 )
-from member.permissions import is_core_or_admin, is_pickleader_or_core
+from member.permissions import is_core_or_admin, is_pickleader_or_core_or_admin
 from member.models import Organization
 
 
@@ -304,10 +304,10 @@ class CommentCreateView(PermissionRequiredMixin, SuccessMessageMixin, CreateView
 def harvest_yield_delete(request, id):
     """ deletes a fruit distribution entry (app/harvest/delete_yield.html)"""
 
-    if not is_pickleader_or_core(request.user):
+    if not is_pickleader_or_core_or_admin(request.user):
         messages.error(
             request,
-            _("You must be a pickleader to register delete a fruit distribution entry!")
+            _("You must be a pickleader to delete a fruit distribution entry!")
         )
     else:
         _yield = HarvestYield.objects.get(id=id)
@@ -321,10 +321,10 @@ def harvest_yield_delete(request, id):
 def harvest_yield_create(request):
     """ handles new fruit distribution form (app/harvest/create_yield.html)"""
 
-    if not is_pickleader_or_core(request.user):
+    if not is_pickleader_or_core_or_admin(request.user):
         messages.error(
             request,
-            _("You must be a pickleader to register add a fruit distribution entry!")
+            _("You must be a pickleader to add a fruit distribution entry!")
         )
     elif request.method == 'POST':
         data = request.POST
@@ -363,7 +363,7 @@ def harvest_adopt(request, id):
     """
     harvest = get_object_or_404(Harvest, id=id)
 
-    if not is_pickleader_or_core(request.user):
+    if not is_pickleader_or_core_or_admin(request.user):
         messages.error(
             request,
             _("You must be a pickleader to adopt this harvest!")

--- a/saskatoon/member/serializers.py
+++ b/saskatoon/member/serializers.py
@@ -120,6 +120,12 @@ class PersonOwnerSerializer(serializers.ModelSerializer):
         return obj.person.comments
 
 
+class PickerSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Person
+        fields = ['pk', 'name']
+
+
 class PickLeaderSerializer(serializers.ModelSerializer):
     class Meta:
         model = AuthUser

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/distribution/recipient_select.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/distribution/recipient_select.html
@@ -6,11 +6,11 @@
     <option value={{ property.owner.pk }}>{{ property.owner.name }}</option>
     <option selected disabled>{% translate 'Pickers' %}</option>
     {% for p in pickers %}
-        <option value={{ p.pk }}>{{ p }}</option>
+        <option value={{ p.pk }}>{{ p.name }}</option>
     {% endfor %}
-    <option selected disabled>{% translate 'Organizations' %}</option>
+        <option selected disabled>{% translate 'Organizations' %}</option>
     {% for o in organizations %}
-    <option value={{ o.pk }}>{{ o.civil_name }}</option>
+        <option value={{ o.pk }}>{{ o.civil_name }}</option>
     {% endfor %}
     <option selected disabled hidden>{% translate 'Select a Recipient' %}</option>
 </select>


### PR DESCRIPTION
after switching to using serializers, volunteer pickers were improperly displayed in the fruit distribution dropdown