### PR TITLE
fix: harvest public anouncement serialization

### DIFF
--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -245,8 +245,12 @@ class HarvestDetailSerializer(HarvestSerializer):
     trees = HarvestTreeTypeSerializer(many=True, read_only=True)
     property = HarvestDetailPropertySerializer(many=False, read_only=True)
     requests = RequestForParticipationSerializer(many=True, read_only=True)
+    about = serializers.SerializerMethodField()
     status_display = serializers.SerializerMethodField()
     status_choices = serializers.SerializerMethodField()
+
+    def get_about(self, obj):
+        return obj.about.html
 
     def get_status_display(self, obj):
         return obj.get_status_display()


### PR DESCRIPTION
As discussed [here](https://github.com/LesFruitsDefendus/saskatoon-ng/pull/454#issuecomment-2725490770) the Harvest public anouncement (`about` field) was improperly serialized.


