### PR TITLE
fix: clarify adopt/leave flow

### DIFF
--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -265,13 +265,7 @@ class HarvestDetailSerializer(HarvestSerializer):
         return obj.get_status_display()
 
     def get_status_choices(self, obj):
-        return [
-            Harvest.Status.PENDING,
-            Harvest.Status.SCHEDULED,
-            Harvest.Status.READY,
-            Harvest.Status.SUCCEEDED,
-            Harvest.Status.CANCELLED
-        ]
+        return Harvest.Status.choices
 
 
 class HarvestListPropertySerializer(PropertySerializer):

--- a/saskatoon/harvest/urls.py
+++ b/saskatoon/harvest/urls.py
@@ -38,10 +38,6 @@ urlpatterns = [
          views.harvest_adopt,
          name='harvest-adopt'),
 
-    path(r'harvest/leave/<int:id>/',
-         views.harvest_leave,
-         name='harvest-leave'),
-
     path(r'harvest/status-change/<int:id>/',
          views.harvest_status_change,
          name='harvest-status-change'),

--- a/saskatoon/member/permissions.py
+++ b/saskatoon/member/permissions.py
@@ -4,6 +4,10 @@ from django.utils.translation import gettext_lazy
 from member.models import AuthUser
 
 
+def is_pickleader(user: AuthUser) -> bool:
+    return user.groups.filter(name__in=["pickleader"]).exists()
+
+
 def is_pickleader_or_core(user: AuthUser) -> bool:
     return user.groups.filter(name__in=["pickleader", "core"]).exists()
 

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
@@ -11,12 +11,10 @@
                 <div class="wb-traffic-inner notika-shadow sm-res-mg-t-30 tb-res-mg-t-30">
                     <div class="website-traffic-ctn">
                         <p>{% translate "Harvest status" %}</p>
-                        {% if user|is_core_or_admin %}
-                            {% include 'app/detail_views/harvest/status_choices.html' %}
-                        {% elif pick_leader is not None and pick_leader.id == request.user.id %}
+                        {% if user|is_pickleader:id %}
                             {% include 'app/detail_views/harvest/status_choices.html' %}
                         {% else %}
-                        <h2>{{ status }}</h2>
+                            <h2>{{ status_display }}</h2>
                         {% endif %}
                     </div>
                 </div>
@@ -56,34 +54,19 @@
                             <div class="col-lg-8">
                                 <h2>{% trans "Missing" %}</h2>
                             </div>
-                            <div class="col-lg-4 breadcomb-report">
+                            {% if user|is_pickleader and not user|is_pickleader:id %}
+                            <div class="col-lg-4">
                                 <a href="{% url 'harvest-adopt' id %}">
                                     <button
                                     data-placement="left"
                                     title="Adopt it!"
-                                    class="btn"
+                                    class="btn btn-success notika-btn-success"
                                     >
                                         {% trans "Adopt it!" %}
                                     </button>
                                 </a>
                             </div>
-                        </div>
-                        {% elif pick_leader.id == request.user.id %}
-                        <div class="row">
-                            <div class="col-lg-7">
-                                <h2>{{ pick_leader.name }}</h2>
-                            </div>
-                            <div class="col-lg-5 breadcomb-report">
-                                <a href="{% url 'harvest-leave' id %}">
-                                    <button
-                                    data-placement="left"
-                                    title="Leave it!"
-                                    class="btn"
-                                    >
-                                        {% trans "Leave it!" %}
-                                    </button>
-                                </a>
-                            </div>
+                            {% endif %}
                         </div>
                         {% else %}
                         <h2>{{ pick_leader.name }}</h2>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/status_choices.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/status_choices.html
@@ -28,11 +28,11 @@
         {% for choice in status_choices %}
             <li role="presentation">
                 <a
-                href="{% url 'harvest-status-change' id %}?status={{ choice }}"
+                href="{% url 'harvest-status-change' id %}?status={{ choice.0 }}"
                 role="menuitem"
                 tabindex="-1"
                 >
-                {{ choice.label }}
+                {{ choice.1 }}
             </a>
             </li>
             {% if not forloop.last %}

--- a/saskatoon/sitebase/templatetags/auth_users.py
+++ b/saskatoon/sitebase/templatetags/auth_users.py
@@ -1,5 +1,9 @@
 from django import template
+from typing import Optional
+
+from harvest.models import Harvest
 from member.models import AuthUser
+import member.permissions as perms
 
 register = template.Library()
 
@@ -13,4 +17,15 @@ def is_person(actor):
 def is_core_or_admin(user: AuthUser) -> bool:
     """checks if the user making the request has the groups core or admin"""
 
-    return user.groups.filter(name__in=("admin", "core")).exists()
+    return perms.is_core_or_admin(user)
+
+
+@register.filter(name="is_pickleader")
+def is_pickleader(user: AuthUser, hid: Optional[int] = None) -> bool:
+    """ checks if the user making the request is a or *the* pickleader"""
+
+    if hid is not None:
+        harvest = Harvest.objects.get(id=hid)
+        return harvest.pick_leader == user
+
+    return perms.is_pickleader_or_core(user)

--- a/saskatoon/unittests/baselines/harvest_detail.json
+++ b/saskatoon/unittests/baselines/harvest_detail.json
@@ -305,11 +305,13 @@
     "about": "<p>Un tas de belles pommes et de noix de Grenoble au coin Mont-Royal et Buillon</p>",
     "status_display": "Succeeded",
     "status_choices": [
-        "pending",
-        "scheduled",
-        "ready",
-        "succeeded",
-        "cancelled"
+        ["orphan", "Orphan"],
+        ["adopted", "Adopted"],
+        ["pending", "To be confirmed"],
+        ["scheduled", "Date scheduled"],
+        ["ready", "Ready"],
+        ["succeeded", "Succeeded"],
+        ["cancelled", "Cancelled"]
     ],
     "end_date": "2021-07-19T19:00:00-04:00",
     "nb_required_pickers": 3


### PR DESCRIPTION
#486
#479
#473

- prevent leaving a harvest if there are unresolved requests
- automatically set Pickleader to None when selecting Orphan status
- remove `harvest-leave` route: using 'orphan' in status drowdown instead
