### PR TITLE
fix: clarify Harvest is open for requests

### DIFF
--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -177,7 +177,8 @@ class HarvestSerializer(serializers.ModelSerializer):
     total_distribution = serializers.ReadOnlyField(
         source='get_total_distribution'
     )
-    is_open_to_requests = serializers.ReadOnlyField()
+    is_open_to_requests = serializers.SerializerMethodField()
+    is_open_to_public_requests = serializers.SerializerMethodField()
     start_date = serializers.DateTimeField(
         source='get_local_start',
         format=r"%a. %b. %-d, %Y"
@@ -199,6 +200,12 @@ class HarvestSerializer(serializers.ModelSerializer):
     comment = CommentSerializer(many=True, read_only=True)
     pickers = serializers.SerializerMethodField()
     organizations = serializers.SerializerMethodField()
+
+    def get_is_open_to_requests(self, obj):
+        return obj.is_open_to_requests(False)
+
+    def get_is_open_to_public_requests(self, obj):
+        return obj.is_open_to_requests(True)
 
     def get_pickers(self, obj):
         rfps = RFP.objects.select_related('person').filter(

--- a/saskatoon/harvest/views.py
+++ b/saskatoon/harvest/views.py
@@ -233,8 +233,13 @@ class RequestForParticipationCreateView(SuccessMessageMixin, CreateView):
         if self.harvest is None:
             return context | {'error': _("Something went wrong")}
 
-        if self.request.user.is_authenticated or \
-           self.harvest.is_open_to_requests():
+        if (
+                (
+                    self.request.user.is_authenticated and
+                    self.harvest.is_open_to_requests(False)
+                ) or
+                self.harvest.is_open_to_requests(True)
+        ):
             return context | {
                 'title': _("Request to join this harvest"),
                 'harvest': self.harvest,

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/data_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/data_table.html
@@ -16,10 +16,12 @@
                             </div>
                                 <div class="col-xs-6">
                                     <a href="{% url 'rfp-create' id %}"
-                                    {% if is_open_to_requests %}
+                                    {% if is_open_to_public_requests %}
                                         class="btn btn-success notika-btn-success waves-effect"
-                                    {% else %}
+                                    {% elif is_open_to_requests %}
                                         class="btn btn-danger notika-btn-danger waves-effect"
+                                    {% else %}
+                                       class="btn btn-info notika-btn-info disabled"
                                     {% endif %}
                                         style="float: right">
                                         <i class="fa fa-plus"></i> {% trans "New request" %}

--- a/saskatoon/unittests/baselines/harvest_detail.json
+++ b/saskatoon/unittests/baselines/harvest_detail.json
@@ -2,6 +2,7 @@
     "id": 1,
     "total_distribution": 15.0,
     "is_open_to_requests": false,
+    "is_open_to_public_requests": false,
     "start_date": "Mon. Jul. 19, 2021",
     "start_time": "4:00 PM",
     "end_time": "7:00 PM",


### PR DESCRIPTION
Addresses #482 

This PR clarifies when a Harvest is open for requests on the Public facing calendar _vs_ allowing pick-leaders to manually add new requests from the harvest detail page even when the status is not strictly set to "Scheduled". Note the `New Request` button should be :
- green if the harvest is open for PUBLIC requests
- red if the harvest can still accept new requests made by the pickleader manually
- grey (disabled) if the harvest can no longer receive requests

This PR does not introduce any restriction related to the _number of already accepted pickers_ vs the _number of required pickers_. To remove the harvest from the public calendar, the harvest status should be switched to "Ready" and it's been asked in the past that we keep this process manual so that it remains the responsibility of the pickleader to decide when enough requests have been received (for example it can allow to receive more pending requests as buffer). 

Note: in a separate PR we will make sure we cannot *accept* more requests that are required for the harvest