### PR TITLE
fix: automatically set status to adopted if pickleader is selected

### DIFF
--- a/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
@@ -54,12 +54,12 @@
                             <div class="col-lg-8">
                                 <h2>{% trans "Missing" %}</h2>
                             </div>
-                            {% if user|is_pickleader and not user|is_pickleader:id %}
+                            {% if status == 'orphan' and user|is_pickleader and not user|is_pickleader:id %}
                             <div class="col-lg-4">
                                 <a href="{% url 'harvest-adopt' id %}">
                                     <button
                                     data-placement="left"
-                                    title="Adopt it!"
+                                    title="Adopt"
                                     class="btn btn-success notika-btn-success"
                                     >
                                         {% trans "Adopt it!" %}


### PR DESCRIPTION
Addresses #470 :
- when using the Harvest Edit form, if the status is set to Orphan but a pickleader is selected, then the status will be automatically set to "Adopted"
- the `Adopt it!` button is now only visible if the harvest status is currently set to "orphan"
