### PR TITLE
chore: deprecate Harvest Pending status

### DIFF
--- a/saskatoon/harvest/filters.py
+++ b/saskatoon/harvest/filters.py
@@ -49,7 +49,7 @@ class HarvestFilter(filters.FilterSet):
 
     status = filters.ChoiceFilter(
         label=_("Status"),
-        choices=list(Harvest.Status.choices)
+        choices=list(Harvest.get_status_choices())
     )
 
     pick_leader = filters.ModelChoiceFilter(

--- a/saskatoon/harvest/models.py
+++ b/saskatoon/harvest/models.py
@@ -601,6 +601,12 @@ class Harvest(models.Model):
             )
         return _("Harvest for {}").format(self.property)
 
+    @staticmethod
+    def get_status_choices():
+        """Pending status is no longer used"""
+        return [s for s in Harvest.Status.choices
+                if s[0] != Harvest.Status.PENDING]
+
     def get_total_distribution(self):
         yields = HarvestYield.objects.filter(harvest=self)
         return sum([y.total_in_lb for y in yields])

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -292,8 +292,8 @@ class HarvestDetailSerializer(HarvestSerializer):
     def get_about(self, obj):
         return obj.about.html
 
-    def get_status_choices(self, obj):
-        return Harvest.Status.choices
+    def get_status_choices(self, _obj):
+        return Harvest.get_status_choices()
 
 
 class HarvestListPropertySerializer(PropertySerializer):

--- a/saskatoon/unittests/baselines/harvest_detail.json
+++ b/saskatoon/unittests/baselines/harvest_detail.json
@@ -336,10 +336,6 @@
             "Adopted"
         ],
         [
-            "pending",
-            "To be confirmed"
-        ],
-        [
             "scheduled",
             "Scheduled"
         ],


### PR DESCRIPTION
This PR simplifies the Harvest flow by removing the rarely used "To be Confirmed" Harvest Status.

The `Adopted` status can simply be used instead.