### PR TITLE
only show edit harvest button to core, admin, or harvest pickleader (#544)

### DIFF
--- a/saskatoon/sitebase/templates/app/detail_views/harvest/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/breadcomb.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load static %}
+{% load auth_users %}
 
 {% get_current_language as LANG %}
 <div class="breadcomb-area">
@@ -27,6 +28,7 @@
                         </div>
                         <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
                             <div class="breadcomb-report">
+                                {% if user|is_core_or_admin or user|is_pickleader:id %}
                                 <a href="{% url 'harvest-update' id %}">
                                     <button data-placement="left" title="Edit harvest" class="btn">
 
@@ -34,6 +36,7 @@
                                        {% trans "Edit Harvest" %}
                                     </button>
                                 </a>
+                                {% endif %}
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Fixes #544

----------
## Type of change:
- [x] Bug fix (change which fixes an issue).
- [ ] New feature (change which adds functionality).
- [ ] Changes to models (requires making migrations).
- [ ] Documentation change.
----------
## What's Changed:
- Hide edit harvest button for pick leaders that haven't adopted it
<img width="1187" height="389" alt="Screenshot 2025-10-18 at 11 28 16 AM" src="https://github.com/user-attachments/assets/7aa6524f-42e8-4eac-a06d-4dbda90f69e3" />

## Notes:
- For editing pickers requests, it seems like this was already restricted. No change needed
<img width="1176" height="253" alt="Screenshot 2025-10-18 at 11 27 47 AM" src="https://github.com/user-attachments/assets/ab41ece6-07ae-4c86-8c04-b9372e5ada47" />

## Questions:
1. I saw pick leaders can leave comments on another's harvest. Is that intentional or should also be restricted?

2. I saw in your screenshot pick leaders can't edit a property's information but in prod they can. Does that have to do with dynamic permissions stored in DB and different in prod vs in fixtures? Should this be restricted?

--------
## Affected URLs:
`/harvest/:id`

-------
## Checklist:
- [x] My code follows the [style guidelines](https://github.com/LesFruitsDefendus/saskatoon-ng/blob/develop/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
