### PR TITLE
chore: improve date_range display when end_date > start_date

### DIFF
--- a/saskatoon/harvest/models.py
+++ b/saskatoon/harvest/models.py
@@ -634,11 +634,11 @@ class Harvest(models.Model):
     def get_local_end(self):
         return local_datetime(self.end_date)
 
-    def get_date_range(self) -> Optional[str]:
+    def get_date_range(self) -> str:
         start = self.get_local_start()
         end = self.get_local_end()
         if start is None or end is None or start.date() == end.date():
-            return None
+            return ""
 
         return "{} - {}".format(
             start.strftime("%b. %-d"),

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -221,6 +221,7 @@ class HarvestSerializer(serializers.ModelSerializer):
         source='get_local_end',
         format=r"%-I:%M %p"
     )
+    date_range = serializers.ReadOnlyField(source='get_date_range')
     status = serializers.StringRelatedField(many=False)
     status_display = serializers.ReadOnlyField(source='get_status_display')
     pick_leader = PickLeaderSerializer(many=False, read_only=True)
@@ -231,7 +232,6 @@ class HarvestSerializer(serializers.ModelSerializer):
     comment = CommentSerializer(many=True, read_only=True)
     pickers = serializers.SerializerMethodField()
     organizations = serializers.SerializerMethodField()
-    maturity_range = serializers.SerializerMethodField()
 
     def get_volunteers_count(self, obj):
         return obj.get_volunteers_count(status=RFP.Status.ACCEPTED)
@@ -253,10 +253,6 @@ class HarvestSerializer(serializers.ModelSerializer):
     def get_organizations(self, obj):
         organizations = Organization.objects.filter(is_beneficiary=True)
         return OrganizationSerializer(organizations, many=True).data
-
-    def get_maturity_range(self, obj):
-        date_range = obj.get_date_range()
-        return date_range if date_range is not None else ""
 
 
 class HarvestBeneficiarySerializer(serializers.ModelSerializer):
@@ -325,6 +321,7 @@ class HarvestListSerializer(HarvestSerializer):
             'start_date',
             'start_time',
             'end_time',
+            'date_range',
             'status',
             'status_display',
             'pick_leader',

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/status.html
@@ -22,9 +22,9 @@
             <div class="col-lg-3 col-md-6 col-sm-6 col-xs-12">
                 <div class="wb-traffic-inner notika-shadow sm-res-mg-t-30 tb-res-mg-t-30">
                     <div class="website-traffic-ctn">
-                        {% if maturity_range %}
+                        {% if date_range %}
                             <p> {% translate "Expected maturity" %}</p>
-                            <h2>{{maturity_range}}</h2>
+                            <h2>{{date_range}}</h2>
                         {% else %}
                             <p>{{start_time}} {% trans "to" %} {{end_time}}</p>
                             <h2>{{start_date}} </h2>

--- a/saskatoon/sitebase/templates/app/list_views/harvest/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/harvest/data_row.html
@@ -6,7 +6,7 @@
 <tr>
     <td>
         <a href="{% url 'harvest-detail' harvest.id %}">
-           # {{ harvest.id }}&nbsp;
+            # {{ harvest.id }}&nbsp;
             <small><i class="fa fa-pencil"></i></small>
         </a>
         {% if perms.harvest.delete_harvest %}
@@ -20,8 +20,14 @@
         {% endif %}
     </td>
     <td>
-        <div class="text-nowrap">{{ harvest.start_date }}</div>
-        <small>{{ harvest.start_time }}</small>
+        <div class="text-nowrap">
+        {% if harvest.date_range %}
+            {{ harvest.date_range }}
+        {% else %}
+            <b>{{ harvest.start_date }}</b><br>
+            <small>{{ harvest.start_time }} - {{ harvest.end_time}}</small>
+        {% endif %}
+        </div>
     </td>
     <td>
         <div class="skill">

--- a/saskatoon/unittests/baselines/harvest_detail.json
+++ b/saskatoon/unittests/baselines/harvest_detail.json
@@ -7,6 +7,7 @@
     "start_date": "Mon. Jul. 19, 2021",
     "start_time": "4:00 PM",
     "end_time": "7:00 PM",
+    "date_range": "",
     "status": "succeeded",
     "status_display": "Succeeded",
     "pick_leader": {
@@ -287,7 +288,6 @@
             }
         }
     ],
-    "maturity_range": "",
     "comments": [
         {
             "id": 1,

--- a/saskatoon/unittests/baselines/harvest_list.json
+++ b/saskatoon/unittests/baselines/harvest_list.json
@@ -11,6 +11,7 @@
             "start_date": "Sun. Aug. 1, 2021",
             "start_time": "9:00 AM",
             "end_time": "12:00 PM",
+            "date_range": "",
             "status": "scheduled",
             "status_display": "Scheduled",
             "pick_leader": {
@@ -47,6 +48,7 @@
             "start_date": "Sat. Jul. 24, 2021",
             "start_time": "3:00 PM",
             "end_time": "6:00 PM",
+            "date_range": "",
             "status": "ready",
             "status_display": "Ready",
             "pick_leader": {
@@ -83,6 +85,7 @@
             "start_date": "Thu. Jul. 22, 2021",
             "start_time": "5:00 PM",
             "end_time": "6:00 PM",
+            "date_range": "",
             "status": "cancelled",
             "status_display": "Cancelled",
             "pick_leader": {
@@ -119,6 +122,7 @@
             "start_date": "Mon. Jul. 19, 2021",
             "start_time": "4:00 PM",
             "end_time": "7:00 PM",
+            "date_range": "",
             "status": "succeeded",
             "status_display": "Succeeded",
             "pick_leader": {


### PR DESCRIPTION
This PR changes the date display in the Harvest List View for Orphan and Adopted harvests (when `end_date` != `start_date`)