### PR TITLE
Fix past reservations button

### DIFF
--- a/saskatoon/sitebase/templates/app/detail_views/organization/harvest_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/harvest_table.html
@@ -9,7 +9,7 @@
             <div>
               <h4> {% trans "Upcoming Reservations" %} </h4>
 
-            <a class="btn btn-primary notika-btn-primary waves-effect" href="/harvest?date=past&has_equipment_point=on&equipment_point={{ actor_id }}">
+            <a class="btn btn-primary notika-btn-primary waves-effect" href="/harvest/?date=past&has_equipment_point=on&equipment_point={{ actor_id }}">
               See past reservations
             </a>
 


### PR DESCRIPTION
While it worked locally, prod requires url's to end with `/` before the query part.