### PR TITLE
fix: prevent booking equipment while another harvest is using it

### DIFF
--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -22,7 +22,7 @@ from harvest.models import (
 )
 from member.forms import validate_email
 from member.models import AuthUser, Person, Organization
-from member.utils import is_equipment_point_available, get_available_equipment_points
+from member.utils import is_equipment_point_available
 from sitebase.models import Email, EmailType
 from sitebase.serializers import EmailRFPSerializer
 from sitebase.utils import is_quill_html_empty

--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -22,7 +22,7 @@ from harvest.models import (
 )
 from member.forms import validate_email
 from member.models import AuthUser, Person, Organization
-from member.utils import is_equipment_point_available
+from member.utils import is_equipment_point_available, get_available_equipment_points
 from sitebase.models import Email, EmailType
 from sitebase.serializers import EmailRFPSerializer
 from sitebase.utils import is_quill_html_empty
@@ -611,9 +611,7 @@ class HarvestForm(forms.ModelForm[Harvest]):
             # the harvest model still has a list of reserved equipment. This means that
             # any equipment reservation for a harvest will make that entire equipment
             # point reserved, even if part of it's equipment has not been added to the harvest
-            instance.equipment_reserved.set(
-                Equipment.objects.filter(owner=equipment_point)
-            )
+            instance.equipment_reserved.set(Equipment.objects.filter(owner=equipment_point))
             instance.save()
 
         return instance

--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -22,7 +22,7 @@ from harvest.models import (
 )
 from member.forms import validate_email
 from member.models import AuthUser, Person, Organization
-from member.utils import available_equipment_points
+from member.utils import is_equipment_point_available
 from sitebase.models import Email, EmailType
 from sitebase.serializers import EmailRFPSerializer
 from sitebase.utils import is_quill_html_empty
@@ -560,13 +560,7 @@ class HarvestForm(forms.ModelForm[Harvest]):
         start = self.cleaned_data.get('start_date', None)
         end = self.cleaned_data.get('end_date', None)
 
-        available_points = (
-            available_equipment_points(start, end, harvest)
-            if start is not None and end is not None
-            else Organization.objects.none()
-        )
-
-        if available_points.filter(pk=equipment_point.pk).count() != 1:
+        if not is_equipment_point_available(equipment_point, start, end, harvest):
             raise forms.ValidationError(
                 _("The {} equipment point is no longer available.").format(
                     equipment_point.civil_name
@@ -611,13 +605,16 @@ class HarvestForm(forms.ModelForm[Harvest]):
         instance = super().save(commit=True)
 
         equipment_point = self.cleaned_data['equipment_point']
-        equipment = (
-            Equipment.objects.none()
-            if equipment_point is None
-            else Equipment.objects.filter(owner=equipment_point)
-        )
-        instance.equipment_reserved.set(equipment)
-        instance.save()
+        if equipment_point is not None:
+            # To keep things simple, pick leaders must reserve entire equipment points.
+            # But in the interest of allowing a more granular system in the future,
+            # the harvest model still has a list of reserved equipment. This means that
+            # any equipment reservation for a harvest will make that entire equipment
+            # point reserved, even if part of it's equipment has not been added to the harvest
+            instance.equipment_reserved.set(
+                Equipment.objects.filter(owner=equipment_point)
+            )
+            instance.save()
 
         return instance
 

--- a/saskatoon/harvest/models.py
+++ b/saskatoon/harvest/models.py
@@ -534,7 +534,7 @@ class Harvest(models.Model):
 
     SEASON_CHOICES = [(y, y) for y in range(datetime.now().year, 2015, -1)]
 
-    ALLOWED_TO_RESERVE = [Status.READY, Status.SCHEDULED, Status.SUCCEEDED]
+    CAN_RESERVE_EQUIPMENT = [Status.READY, Status.SCHEDULED, Status.SUCCEEDED]
 
     status = models.CharField(
         choices=Status.choices,

--- a/saskatoon/harvest/models.py
+++ b/saskatoon/harvest/models.py
@@ -534,6 +534,8 @@ class Harvest(models.Model):
 
     SEASON_CHOICES = [(y, y) for y in range(datetime.now().year, 2015, -1)]
 
+    ALLOWED_TO_RESERVE = [Status.READY, Status.SCHEDULED, Status.SUCCEEDED]
+
     status = models.CharField(
         choices=Status.choices,
         max_length=20,

--- a/saskatoon/member/autocomplete.py
+++ b/saskatoon/member/autocomplete.py
@@ -4,7 +4,7 @@ from typeguard import typechecked
 
 from harvest.models import Harvest
 from member.models import AuthUser, Organization, Person, Actor, Neighborhood
-from member.utils import available_equipment_points
+from member.utils import get_available_equipment_points
 from saskatoon.autocomplete import Autocomplete
 from sitebase.utils import parse_naive_datetime
 
@@ -152,7 +152,7 @@ class EquipmentPointAutocomplete(Autocomplete):
         except (Harvest.DoesNotExist, ValueError):
             harvest = None
 
-        return available_equipment_points(start, end, harvest).distinct()
+        return get_available_equipment_points(start, end, harvest)
 
 
 @typechecked

--- a/saskatoon/member/filters.py
+++ b/saskatoon/member/filters.py
@@ -9,7 +9,7 @@ from typeguard import typechecked
 from datetime import datetime, timezone, timedelta
 from django.db.models import QuerySet
 
-from member.utils import available_equipment_points
+from member.utils import get_available_equipment_points
 from member.models import AuthUser, Organization, Person, Neighborhood
 from harvest.models import EquipmentType, Equipment, Harvest, RequestForParticipation
 
@@ -240,11 +240,11 @@ class EquipmentPointFilter(filters.FilterSet):
         filtered = sup.filter_queryset(queryset) if sup.is_valid() else queryset
 
         if self.status_val == 'reserved' and self.start_val < self.end_val:
-            available = available_equipment_points(self.start_val, self.end_val, None)
+            available = get_available_equipment_points(self.start_val, self.end_val)
             return filtered.exclude(pk__in=available)
 
         if self.status_val == 'available' and self.start_val < self.end_val:
-            available = available_equipment_points(self.start_val, self.end_val, None)
+            available = get_available_equipment_points(self.start_val, self.end_val)
             return filtered.filter(pk__in=available)
 
         return filtered

--- a/saskatoon/member/utils.py
+++ b/saskatoon/member/utils.py
@@ -66,20 +66,30 @@ def get_available_equipment_points(
 
     # If another harvest has already reserved the equipment available in the equipment
     # point and its datetime range overlaps, then the equipment point is unavailable.
-    has_datetimes = Q(harvest__status__in=[Harvest.Status.SCHEDULED, Harvest.Status.READY])
-    start_between = Q(
-        harvest__start_date__gte=start, harvest__start_date__lte=end
-    )  # start <= si <= end
-    end_between = Q(harvest__end_date__gte=start, harvest__end_date__lte=end)  # start <= ei <= end
-    wrapping = Q(harvest__start_date__lte=start, harvest__end_date__gte=end)
+    has_datetimes = Q(harvest__status__in=Harvest.ALLOWED_TO_RESERVE)
+    start_between = Q(harvest__start_date__gte=start, harvest__start_date__lte=end)
+    end_between = Q(harvest__end_date__gte=start, harvest__end_date__lte=end)
+    surround = Q(harvest__start_date__lte=start, harvest__end_date__gte=end)
 
     booked_equipment = Equipment.objects.filter(
-        has_datetimes & (start_between | end_between | wrapping)
+        has_datetimes & (start_between | end_between | surround)
     )
 
     # Make sure harvest doesn't conflict with itself
     if harvest is not None:
-        booked_equipment = booked_equipment.exclude(harvest__pk=harvest.pk)
+        has_datetimes = Q(status__in=Harvest.ALLOWED_TO_RESERVE)
+        start_between = Q(start_date__gte=start, start_date__lte=end)
+        end_between = Q(end_date__gte=start, end_date__lte=end)
+        surround = Q(start_date__lte=start, end_date__gte=end)
+        same_reservation = Q(equipment_reserved__pk__in=harvest.equipment_reserved.all())
+        different = ~Q(pk=harvest.pk)
+
+        harvests = Harvest.objects.filter(
+            different & has_datetimes & (start_between | end_between | surround) & same_reservation
+        )
+
+        if harvests.count() == 0:
+            booked_equipment = booked_equipment.exclude(harvest__pk=harvest.pk)
 
     return Organization.objects.filter(is_equipment_point=True).exclude(
         pk__in=booked_equipment.values('owner')

--- a/saskatoon/member/utils.py
+++ b/saskatoon/member/utils.py
@@ -66,7 +66,7 @@ def get_available_equipment_points(
 
     # If another harvest has already reserved the equipment available in the equipment
     # point and its datetime range overlaps, then the equipment point is unavailable.
-    query = Q(status__in=Harvest.ALLOWED_TO_RESERVE)
+    query = Q(status__in=Harvest.CAN_RESERVE_EQUIPMENT)
 
     # Dont include itself
     if harvest is not None:

--- a/saskatoon/member/utils.py
+++ b/saskatoon/member/utils.py
@@ -61,35 +61,23 @@ def get_available_equipment_points(
 
     # A buffer gives pick leaders a bit of leeway in picking up and returning
     # the equipment, since some harvest sites can be further away
-    start = start - buffer
-    end = end + buffer
+    requested_start = start - buffer
+    requested_end = end + buffer
 
     # If another harvest has already reserved the equipment available in the equipment
     # point and its datetime range overlaps, then the equipment point is unavailable.
-    has_datetimes = Q(harvest__status__in=Harvest.ALLOWED_TO_RESERVE)
-    start_between = Q(harvest__start_date__gte=start, harvest__start_date__lte=end)
-    end_between = Q(harvest__end_date__gte=start, harvest__end_date__lte=end)
-    surround = Q(harvest__start_date__lte=start, harvest__end_date__gte=end)
+    query = Q(status__in=Harvest.ALLOWED_TO_RESERVE)
 
-    booked_equipment = Equipment.objects.filter(
-        has_datetimes & (start_between | end_between | surround)
-    )
-
-    # Make sure harvest doesn't conflict with itself
+    # Dont include itself
     if harvest is not None:
-        has_datetimes = Q(status__in=Harvest.ALLOWED_TO_RESERVE)
-        start_between = Q(start_date__gte=start, start_date__lte=end)
-        end_between = Q(end_date__gte=start, end_date__lte=end)
-        surround = Q(start_date__lte=start, end_date__gte=end)
-        same_reservation = Q(equipment_reserved__pk__in=harvest.equipment_reserved.all())
-        different = ~Q(pk=harvest.pk)
+        query = query & ~Q(pk=harvest.pk)
 
-        harvests = Harvest.objects.filter(
-            different & has_datetimes & (start_between | end_between | surround) & same_reservation
-        )
+    start_between = Q(start_date__gte=requested_start, start_date__lte=requested_end)
+    end_between = Q(end_date__gte=requested_start, end_date__lte=requested_end)
+    surround = Q(start_date__lte=requested_start, end_date__gte=requested_end)
 
-        if harvests.count() == 0:
-            booked_equipment = booked_equipment.exclude(harvest__pk=harvest.pk)
+    conflicts = Harvest.objects.filter(query & (start_between | end_between | surround))
+    booked_equipment = Equipment.objects.filter(pk__in=conflicts.values('equipment_reserved'))
 
     return Organization.objects.filter(is_equipment_point=True).exclude(
         pk__in=booked_equipment.values('owner')

--- a/saskatoon/member/utils.py
+++ b/saskatoon/member/utils.py
@@ -67,9 +67,12 @@ def get_available_equipment_points(
     # If another harvest has already reserved the equipment available in the equipment
     # point and its datetime range overlaps, then the equipment point is unavailable.
     has_datetimes = Q(harvest__status__in=[Harvest.Status.SCHEDULED, Harvest.Status.READY])
-    start_between = Q(harvest__start_date__gte=start, harvest__start_date__lte=end)  # start <= si <= end
+    start_between = Q(
+        harvest__start_date__gte=start, harvest__start_date__lte=end
+    )  # start <= si <= end
     end_between = Q(harvest__end_date__gte=start, harvest__end_date__lte=end)  # start <= ei <= end
-    wrapping = Q(harvest__start_date__lte=start, harvest__end_date__gte=end)  # si <= start < end <= ei
+    wrapping = Q(harvest__start_date__lte=start, harvest__end_date__gte=end)
+
     booked_equipment = Equipment.objects.filter(
         has_datetimes & (start_between | end_between | wrapping)
     )
@@ -88,7 +91,7 @@ def is_equipment_point_available(
     org: Organization,
     start: Union[datetime, None],
     end: Union[datetime, None],
-    harvest: Optional[Harvest] = None
+    harvest: Optional[Harvest] = None,
 ) -> bool:
     """Check if an equipment point is available for a given time range"""
 

--- a/saskatoon/member/utils.py
+++ b/saskatoon/member/utils.py
@@ -4,7 +4,7 @@ from django.db.models import Q, QuerySet
 from datetime import timedelta, datetime
 from secrets import choice
 from typeguard import typechecked
-from typing import Optional
+from typing import Optional, Union
 
 from member.models import AuthUser, Organization
 from harvest.models import Equipment, Harvest
@@ -51,46 +51,48 @@ def _valid_date_contract(_) -> bool:
     message="start and end must be offset aware",
 )
 @typechecked
-def available_equipment_points(
+def get_available_equipment_points(
     start: datetime,
     end: datetime,
-    harvest: Optional[Harvest],
+    harvest: Optional[Harvest] = None,
     buffer: timedelta = timedelta(hours=DEFAULT_RESERVATION_BUFFER),
 ) -> QuerySet[Organization]:
     """List all available equipment points for a given datetime range"""
 
-    try:
-        # A buffer gives pick leaders a bit of leeway in picking up and returning
-        # the equipment, since some harvest sites can be further away
-        start = start - buffer
-        end = end + buffer
+    # A buffer gives pick leaders a bit of leeway in picking up and returning
+    # the equipment, since some harvest sites can be further away
+    start = start - buffer
+    end = end + buffer
 
-        # If a harvest has already reserved the equipment point and starts or ends during the
-        # requested date range, then the equipment point is unavailable
-        start_between = Q(harvest__start_date__gte=start) & Q(harvest__start_date__lte=end)
-        end_between = Q(harvest__end_date__gte=start) & Q(harvest__end_date__lte=end)
+    # If another harvest has already reserved the equipment available in the equipment
+    # point and its datetime range overlaps, then the equipment point is unavailable.
+    has_datetimes = Q(harvest__status__in=[Harvest.Status.SCHEDULED, Harvest.Status.READY])
+    start_between = Q(harvest__start_date__gte=start, harvest__start_date__lte=end)  # start <= si <= end
+    end_between = Q(harvest__end_date__gte=start, harvest__end_date__lte=end)  # start <= ei <= end
+    wrapping = Q(harvest__start_date__lte=start, harvest__end_date__gte=end)  # si <= start < end <= ei
+    booked_equipment = Equipment.objects.filter(
+        has_datetimes & (start_between | end_between | wrapping)
+    )
 
-        # We only want scheduled and ready harvests to impact availability
-        is_active = Q(harvest__status__in=[Harvest.Status.SCHEDULED, Harvest.Status.READY])
+    # Make sure harvest doesn't conflict with itself
+    if harvest is not None:
+        booked_equipment = booked_equipment.exclude(harvest__pk=harvest.pk)
 
-        not_conflicting = (start_between | end_between) & is_active
+    return Organization.objects.filter(is_equipment_point=True).exclude(
+        pk__in=booked_equipment.values('owner')
+    )
 
-        # We need to exclude the present harvest from the results
-        # so it doesnt conflict with itself
-        id = getattr(harvest, "pk", None)
-        not_itself = ~Q(harvest__pk=id)
 
-        # To keep things simple, pick leaders must reserve entire equipment points.
-        # But in the interest of allowing a more granular system in the future,
-        # the harvest model still has a list of reserved equipment. This means that
-        # any equipment reservation for a harvest will make that entire equipment
-        # point reserved, even if part of it's equipment has not been added to the harvest
-        conflicting_orgs = Equipment.objects.filter(not_itself & not_conflicting).values("owner")
+@typechecked
+def is_equipment_point_available(
+    org: Organization,
+    start: Union[datetime, None],
+    end: Union[datetime, None],
+    harvest: Optional[Harvest] = None
+) -> bool:
+    """Check if an equipment point is available for a given time range"""
 
-        return Organization.objects.filter(is_equipment_point=True).exclude(
-            pk__in=conflicting_orgs
-        )
+    if not org.is_equipment_point or start is None or end is None:
+        return False
 
-    except Exception as _e:
-        logger.warning(_e)
-        return Organization.objects.none()
+    return get_available_equipment_points(start, end, harvest).filter(pk=org.pk).exists()

--- a/saskatoon/unittests/member/test_filters.py
+++ b/saskatoon/unittests/member/test_filters.py
@@ -122,13 +122,15 @@ def test_filter_queryset_reserved(location) -> None:  # noqa: F811
         is_equipment_point=True, civil_name=" Test Equipment Point 2", **location
     )
 
-    equipment_1 = Equipment.objects.create(type=equipment_type, owner=org1)
-    Equipment.objects.create(type=equipment_type2, owner=org2)
-
+    equipment_1 = Equipment.objects.create(type=equipment_type, owner=org1)  # reserved
     harvest = Harvest.objects.create(
         start_date=filter.start_val, end_date=filter.end_val, status=Harvest.Status.SCHEDULED
     )
     harvest.equipment_reserved.set([equipment_1])
+
+    # equipment_2 (available)
+    Equipment.objects.create(type=equipment_type2, owner=org2)
+
     query = filter.filter_queryset(Organization.objects.all())
     assert query.count() == 1
 
@@ -153,13 +155,14 @@ def test_filter_queryset_available(location) -> None:  # noqa: F811
         is_equipment_point=True, civil_name=" Test Equipment Point 2", **location
     )
 
-    equipment_1 = Equipment.objects.create(type=equipment_type, owner=org1)
-    Equipment.objects.create(type=equipment_type2, owner=org2)
-
+    equipment_1 = Equipment.objects.create(type=equipment_type, owner=org1)  # reserved
     harvest = Harvest.objects.create(
         start_date=filter.start_val, end_date=filter.end_val, status=Harvest.Status.SCHEDULED
     )
     harvest.equipment_reserved.set([equipment_1])
+
+    # equipment_2 (available)
+    Equipment.objects.create(type=equipment_type2, owner=org2)
 
     query = filter.filter_queryset(Organization.objects.all())
     assert query.count() == 1

--- a/saskatoon/unittests/member/test_utils.py
+++ b/saskatoon/unittests/member/test_utils.py
@@ -5,7 +5,7 @@ import hypothesis.strategies as st
 
 from django.conf import settings
 from sitebase.utils import parse_naive_datetime
-from member.utils import get_available_equipment_points
+from member.utils import is_equipment_point_available, get_available_equipment_points
 from harvest.models import Harvest, Equipment, EquipmentType
 from member.models import Organization, Country, State, City, Neighborhood
 
@@ -57,7 +57,7 @@ def equipment(db) -> Equipment:
 
 
 @pytest.mark.django_db
-def test_available_equipment_points_fuzz() -> None:
+def test_get_available_equipment_points_fuzz() -> None:
     start_strat = st.datetimes(
         min_value=datetime.min,
         max_value=datetime.max - timedelta(hours=1),
@@ -90,49 +90,51 @@ def test_available_equipment_points_fuzz() -> None:
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
-def test_available_equipment_points_end_during(db, harvest, equipment) -> None:
+def test_is_equipment_point_available_end_during(db, harvest, equipment) -> None:
     """
     If the requested end time is during another reservation,
     there should be no available equipment points.
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = get_available_equipment_points(
+    available = is_equipment_point_available(
+        equipment.owner,
         start.replace(hour=7),
         end.replace(hour=14),
         None,
     )
 
     if harvest.status in Harvest.ALLOWED_TO_RESERVE:
-        assert points.count() == 0
+        assert available is False
     else:
-        assert points.count() == 1
+        assert available is True
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
-def test_available_equipment_points_start_during(db, harvest, equipment) -> None:
+def test_is_equipment_point_available_start_during(db, harvest, equipment) -> None:
     """
     If the requested start time is during another reservation,
     there should no available equipment points.
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = get_available_equipment_points(
+    available = is_equipment_point_available(
+        equipment.owner,
         start.replace(hour=14),
         end.replace(hour=20),
         None,
     )
 
     if harvest.status in Harvest.ALLOWED_TO_RESERVE:
-        assert points.count() == 0
+        assert available is False
     else:
-        assert points.count() == 1
+        assert available is True
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
-def test_available_equipment_points_around(db, harvest, equipment) -> None:
+def test_is_equipment_point_available_around(db, harvest, equipment) -> None:
     """
     If both the requested start and end time is during
     another reservation, there should be no available equipment
@@ -140,56 +142,56 @@ def test_available_equipment_points_around(db, harvest, equipment) -> None:
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = get_available_equipment_points(
+    available = is_equipment_point_available(
+        equipment.owner,
         start.replace(hour=14),
         end.replace(hour=16),
         None,
     )
 
-    print(harvest.start_date)
-    print(harvest.start_date + timedelta(hours=2))
-
     if harvest.status in Harvest.ALLOWED_TO_RESERVE:
-        assert points.count() == 0
+        assert available is False
     else:
-        assert points.count() == 1
+        assert available is True
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
-def test_available_equipment_points_same_dates(db, harvest, equipment) -> None:
+def test_is_equipment_point_available_same_dates(db, harvest, equipment) -> None:
     """
     If the requested times are at the same time as another reservation,
     there should be no available equipment points.
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = get_available_equipment_points(harvest.start_date, harvest.end_date)
+    available = is_equipment_point_available(equipment.owner, harvest.start_date, harvest.end_date)
 
     if harvest.status in Harvest.ALLOWED_TO_RESERVE:
-        assert points.count() == 0
+        assert available is False
     else:
-        assert points.count() == 1
+        assert available is True
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
-def test_available_equipment_points_no_conflict_with_self(db, harvest, equipment) -> None:
+def test_is_equipment_point_available_no_conflict_with_self(db, harvest, equipment) -> None:
     """
     If the harvest has already reserved an equipment point, that equipment point should still
     be listed as available for itself.
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = get_available_equipment_points(harvest.start_date, harvest.end_date, harvest)
+    available = is_equipment_point_available(
+        equipment.owner, harvest.start_date, harvest.end_date, harvest
+    )
 
-    assert points.count() == 1
+    assert available is True
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", [Harvest.Status.SCHEDULED], indirect=True)
 @pytest.mark.parametrize("second_harvest", Harvest.Status, indirect=True)
-def test_available_equipment_points_conflict_when_checking_self(
+def test_is_equipment_point_available_conflict_when_checking_self(
     db, harvest, second_harvest, equipment
 ) -> None:
     """
@@ -199,93 +201,97 @@ def test_available_equipment_points_conflict_when_checking_self(
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = get_available_equipment_points(
-        second_harvest.start_date, second_harvest.end_date, second_harvest
+    available = is_equipment_point_available(
+        equipment.owner, second_harvest.start_date, second_harvest.end_date, second_harvest
     )
 
-    assert points.count() == 0
+    assert available is False
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
-def test_available_equipment_points_after(db, harvest, equipment) -> None:
+def test_is_equipment_point_available_after(db, harvest, equipment) -> None:
     """
     There should be an available equipment point if all
     other reservations are in the past.
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = get_available_equipment_points(
+    available = is_equipment_point_available(
+        equipment.owner,
         start.replace(hour=20),
         end.replace(hour=22),
         None,
     )
 
-    assert points.count() == 1
+    assert available is True
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
-def test_available_equipment_points_before(db, harvest, equipment) -> None:
+def test_is_equipment_point_available_before(db, harvest, equipment) -> None:
     """
     There should be an available equipment point if the next
     reservation if further then the alloted buffer
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = get_available_equipment_points(
+    available = is_equipment_point_available(
+        equipment.owner,
         start.replace(hour=8),
         end.replace(hour=10),
         None,
     )
 
-    assert points.count() == 1
+    assert available is True
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
-def test_available_equipment_points_buffer_after(db, harvest, equipment) -> None:
+def test_is_equipment_point_available_buffer_after(db, harvest, equipment) -> None:
     """
     There should be no available equipment points right after a reservation.
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = get_available_equipment_points(
+    available = is_equipment_point_available(
+        equipment.owner,
         start.replace(hour=18),
         end.replace(hour=20),
         None,
     )
 
     if harvest.status in Harvest.ALLOWED_TO_RESERVE:
-        assert points.count() == 0
+        assert available is False
     else:
-        assert points.count() == 1
+        assert available is True
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
-def test_available_equipment_points_buffer_before(db, harvest, equipment) -> None:
+def test_is_equipment_point_available_buffer_before(db, harvest, equipment) -> None:
     """
     There should be no available equipment points right before a reservation
     """
 
     harvest.equipment_reserved.set([equipment])
 
-    points = get_available_equipment_points(
+    available = is_equipment_point_available(
+        equipment.owner,
         start.replace(hour=8),
         end.replace(hour=12),
         None,
     )
 
     if harvest.status in Harvest.ALLOWED_TO_RESERVE:
-        assert points.count() == 0
+        assert available is False
     else:
-        assert points.count() == 1
+        assert available is True
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
-def test_available_equipment_points_buffer_with_parse_naive_datetime(
+def test_is_equipment_point_available_buffer_with_parse_naive_datetime(
     db, harvest, equipment
 ) -> None:
     """
@@ -299,18 +305,20 @@ def test_available_equipment_points_buffer_with_parse_naive_datetime(
     end = parse_naive_datetime(end_str, settings.DATETIME_INPUT_FORMATS[0])
     assert end is not None
 
-    points = get_available_equipment_points(end.replace(hour=13), end.replace(hour=14), None)
+    available = is_equipment_point_available(
+        equipment.owner, end.replace(hour=13), end.replace(hour=14), None
+    )
 
     if harvest.status in Harvest.ALLOWED_TO_RESERVE:
-        assert points.count() == 0
+        assert available is False
     else:
-        assert points.count() == 1
+        assert available is True
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
 @pytest.mark.parametrize("second_harvest", Harvest.Status, indirect=True)
-def test_available_equipment_points_date_change_after_reservation(
+def test_is_equipment_point_available_date_change_after_reservation(
     db, harvest, second_harvest, equipment
 ) -> None:
     """
@@ -323,29 +331,31 @@ def test_available_equipment_points_date_change_after_reservation(
     second_harvest.start_date = start.replace(day=1)
     second_harvest.end_date = end.replace(day=1)
 
-    before_change_points = get_available_equipment_points(
+    available_before_change = is_equipment_point_available(
+        equipment.owner,
         start,
         end,
         second_harvest,
     )
 
     if harvest.status in Harvest.ALLOWED_TO_RESERVE:
-        assert before_change_points.count() == 0
+        assert available_before_change is False
     else:
-        assert before_change_points.count() == 1
+        assert available_before_change is True
 
     second_harvest.equipment_reserved.set([equipment])
 
     second_harvest.start_date = start.replace(day=2)
     second_harvest.end_date = end.replace(day=2)
 
-    after_change_points = get_available_equipment_points(
+    available_after_change = is_equipment_point_available(
+        equipment.owner,
         start,
         end,
         second_harvest,
     )
 
     if harvest.status in Harvest.ALLOWED_TO_RESERVE:
-        assert after_change_points.count() == 0
+        assert available_after_change is False
     else:
-        assert after_change_points.count() == 1
+        assert available_after_change is True

--- a/saskatoon/unittests/member/test_utils.py
+++ b/saskatoon/unittests/member/test_utils.py
@@ -9,19 +9,19 @@ from member.utils import is_equipment_point_available, get_available_equipment_p
 from harvest.models import Harvest, Equipment, EquipmentType
 from member.models import Organization, Country, State, City, Neighborhood
 
-tzinfo = timezone(timedelta(hours=-5))
-start = datetime(2025, 3, 2, hour=12, minute=0, second=0, microsecond=0, tzinfo=tzinfo)
-end = datetime(2025, 3, 2, hour=18, minute=0, second=0, microsecond=0, tzinfo=tzinfo)
+TZINFO = timezone(timedelta(hours=-5))
+HARVEST_START = datetime(2025, 3, 2, hour=12, tzinfo=TZINFO)
+HARVEST_END = datetime(2025, 3, 2, hour=18, tzinfo=TZINFO)
 
 
 @pytest.fixture
 def harvest(db, request) -> Harvest:
-    return Harvest.objects.create(status=request.param, start_date=start, end_date=end)
+    return Harvest.objects.create(status=request.param, start_date=HARVEST_START, end_date=HARVEST_END)
 
 
 @pytest.fixture
 def second_harvest(db, request) -> Harvest:
-    return Harvest.objects.create(status=request.param, start_date=start, end_date=end)
+    return Harvest.objects.create(status=request.param, start_date=HARVEST_START, end_date=HARVEST_END)
 
 
 @pytest.fixture
@@ -99,12 +99,12 @@ def test_is_equipment_point_available_end_during(db, harvest, equipment) -> None
     harvest.equipment_reserved.set([equipment])
     available = is_equipment_point_available(
         equipment.owner,
-        start.replace(hour=7),
-        end.replace(hour=14),
+        HARVEST_START.replace(hour=7),
+        HARVEST_END.replace(hour=14),
         None,
     )
 
-    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
+    if harvest.status in Harvest.CAN_RESERVE_EQUIPMENT:
         assert available is False
     else:
         assert available is True
@@ -121,12 +121,12 @@ def test_is_equipment_point_available_start_during(db, harvest, equipment) -> No
     harvest.equipment_reserved.set([equipment])
     available = is_equipment_point_available(
         equipment.owner,
-        start.replace(hour=14),
-        end.replace(hour=20),
+        HARVEST_START.replace(hour=14),
+        HARVEST_END.replace(hour=20),
         None,
     )
 
-    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
+    if harvest.status in Harvest.CAN_RESERVE_EQUIPMENT:
         assert available is False
     else:
         assert available is True
@@ -144,12 +144,12 @@ def test_is_equipment_point_available_around(db, harvest, equipment) -> None:
     harvest.equipment_reserved.set([equipment])
     available = is_equipment_point_available(
         equipment.owner,
-        start.replace(hour=14),
-        end.replace(hour=16),
+        HARVEST_START.replace(hour=14),
+        HARVEST_END.replace(hour=16),
         None,
     )
 
-    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
+    if harvest.status in Harvest.CAN_RESERVE_EQUIPMENT:
         assert available is False
     else:
         assert available is True
@@ -166,7 +166,7 @@ def test_is_equipment_point_available_same_dates(db, harvest, equipment) -> None
     harvest.equipment_reserved.set([equipment])
     available = is_equipment_point_available(equipment.owner, harvest.start_date, harvest.end_date)
 
-    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
+    if harvest.status in Harvest.CAN_RESERVE_EQUIPMENT:
         assert available is False
     else:
         assert available is True
@@ -219,8 +219,8 @@ def test_is_equipment_point_available_after(db, harvest, equipment) -> None:
     harvest.equipment_reserved.set([equipment])
     available = is_equipment_point_available(
         equipment.owner,
-        start.replace(hour=20),
-        end.replace(hour=22),
+        HARVEST_START.replace(hour=20),
+        HARVEST_END.replace(hour=22),
         None,
     )
 
@@ -238,8 +238,8 @@ def test_is_equipment_point_available_before(db, harvest, equipment) -> None:
     harvest.equipment_reserved.set([equipment])
     available = is_equipment_point_available(
         equipment.owner,
-        start.replace(hour=8),
-        end.replace(hour=10),
+        HARVEST_START.replace(hour=8),
+        HARVEST_END.replace(hour=10),
         None,
     )
 
@@ -256,12 +256,12 @@ def test_is_equipment_point_available_buffer_after(db, harvest, equipment) -> No
     harvest.equipment_reserved.set([equipment])
     available = is_equipment_point_available(
         equipment.owner,
-        start.replace(hour=18),
-        end.replace(hour=20),
+        HARVEST_START.replace(hour=18),
+        HARVEST_END.replace(hour=20),
         None,
     )
 
-    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
+    if harvest.status in Harvest.CAN_RESERVE_EQUIPMENT:
         assert available is False
     else:
         assert available is True
@@ -278,12 +278,12 @@ def test_is_equipment_point_available_buffer_before(db, harvest, equipment) -> N
 
     available = is_equipment_point_available(
         equipment.owner,
-        start.replace(hour=8),
-        end.replace(hour=12),
+        HARVEST_START.replace(hour=8),
+        HARVEST_END.replace(hour=12),
         None,
     )
 
-    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
+    if harvest.status in Harvest.CAN_RESERVE_EQUIPMENT:
         assert available is False
     else:
         assert available is True
@@ -306,10 +306,10 @@ def test_is_equipment_point_available_buffer_with_parse_naive_datetime(
     assert end is not None
 
     available = is_equipment_point_available(
-        equipment.owner, end.replace(hour=13), end.replace(hour=14), None
+        equipment.owner, HARVEST_END.replace(hour=13), HARVEST_END.replace(hour=14), None
     )
 
-    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
+    if harvest.status in Harvest.CAN_RESERVE_EQUIPMENT:
         assert available is False
     else:
         assert available is True
@@ -328,34 +328,34 @@ def test_is_equipment_point_available_date_change_after_reservation(
     """
 
     harvest.equipment_reserved.set([equipment])
-    second_harvest.start_date = start.replace(day=1)
-    second_harvest.end_date = end.replace(day=1)
+    second_harvest.start_date = HARVEST_START.replace(day=1)
+    second_harvest.end_date = HARVEST_END.replace(day=1)
 
     available_before_change = is_equipment_point_available(
         equipment.owner,
-        start,
-        end,
+        HARVEST_START,
+        HARVEST_END,
         second_harvest,
     )
 
-    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
+    if harvest.status in Harvest.CAN_RESERVE_EQUIPMENT:
         assert available_before_change is False
     else:
         assert available_before_change is True
 
     second_harvest.equipment_reserved.set([equipment])
 
-    second_harvest.start_date = start.replace(day=2)
-    second_harvest.end_date = end.replace(day=2)
+    second_harvest.start_date = HARVEST_START.replace(day=2)
+    second_harvest.end_date = HARVEST_END.replace(day=2)
 
     available_after_change = is_equipment_point_available(
         equipment.owner,
-        start,
-        end,
+        HARVEST_START,
+        HARVEST_END,
         second_harvest,
     )
 
-    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
+    if harvest.status in Harvest.CAN_RESERVE_EQUIPMENT:
         assert available_after_change is False
     else:
         assert available_after_change is True

--- a/saskatoon/unittests/member/test_utils.py
+++ b/saskatoon/unittests/member/test_utils.py
@@ -9,23 +9,19 @@ from member.utils import get_available_equipment_points
 from harvest.models import Harvest, Equipment, EquipmentType
 from member.models import Organization, Country, State, City, Neighborhood
 
+tzinfo = timezone(timedelta(hours=-5))
+start = datetime(2025, 3, 2, hour=12, minute=0, second=0, microsecond=0, tzinfo=tzinfo)
+end = datetime(2025, 3, 2, hour=18, minute=0, second=0, microsecond=0, tzinfo=tzinfo)
+
 
 @pytest.fixture
 def harvest(db, request) -> Harvest:
-    tzinfo = timezone(timedelta(hours=-5))
-    now = datetime.now(tzinfo)
-    delta = delta = timedelta(hours=2)
-
-    return Harvest.objects.create(status=request.param, start_date=now, end_date=now + delta)
+    return Harvest.objects.create(status=request.param, start_date=start, end_date=end)
 
 
 @pytest.fixture
 def second_harvest(db, request) -> Harvest:
-    tzinfo = timezone(timedelta(hours=-5))
-    now = datetime.now(tzinfo)
-    delta = timedelta(hours=2)
-
-    return Harvest.objects.create(status=request.param, start_date=now, end_date=now + delta)
+    return Harvest.objects.create(status=request.param, start_date=start, end_date=end)
 
 
 @pytest.fixture
@@ -60,37 +56,51 @@ def equipment(db) -> Equipment:
     return equipment
 
 
+"""
 @pytest.mark.django_db
 def test_available_equipment_points_fuzz() -> None:
-    date_strat = st.datetimes(
+    start_strat = st.datetimes(
         min_value=datetime.min,
-        max_value=datetime.max,
+        max_value=datetime.max - timedelta(hours=1),
         timezones=st.timezones(),
         allow_imaginary=True,
     )
 
+    end_strat = start_strat.flatmap(
+        lambda d: st.datetimes(
+            timezones=st.just(d.tzinfo),
+            min_value=d.replace(tzinfo=None),
+            max_value=datetime.max,
+            allow_imaginary=True,
+        ),
+     )
+
     cases = deal.cases(
         func=get_available_equipment_points,
-        kwargs=dict(start=date_strat, end=date_strat, harvest=st.just(None)),
+        kwargs=dict(start=start_strat, end=end_strat, harvest=st.just(None)),
     )
 
     for case in cases:
         case()
+"""
+
+# For all cases, we assume that harvests can only reserve an equipment point
+# if they are scheduled or ready and that all equipment point reservations for
+# successfull harvests are in the past.
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
 def test_available_equipment_points_end_during(db, harvest, equipment) -> None:
     """
-    If the requested end time conflicts with another harvest,
-    there should only be an available equipment point if conflicting
-    harvests are not scheduled or ready
+    If the requested end time is during another reservation,
+    there should be no available equipment points.
     """
 
     harvest.equipment_reserved.set([equipment])
     points = get_available_equipment_points(
-        harvest.start_date - timedelta(hours=5),
-        harvest.end_date - timedelta(hours=1),
+        start.replace(hour=7),
+        end.replace(hour=14),
         None,
     )
 
@@ -104,15 +114,14 @@ def test_available_equipment_points_end_during(db, harvest, equipment) -> None:
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
 def test_available_equipment_points_start_during(db, harvest, equipment) -> None:
     """
-    If the requested start time conflicts with another harvest,
-    there should only be an available equipment point if conflicting
-    harvests are not scheduled or ready
+    If the requested start time is during another reservation,
+    there should no available equipment points.
     """
 
     harvest.equipment_reserved.set([equipment])
     points = get_available_equipment_points(
-        harvest.start_date + timedelta(hours=1),
-        harvest.end_date + timedelta(hours=5),
+        start.replace(hour=14),
+        end.replace(hour=20),
         None,
     )
 
@@ -126,17 +135,20 @@ def test_available_equipment_points_start_during(db, harvest, equipment) -> None
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
 def test_available_equipment_points_around(db, harvest, equipment) -> None:
     """
-    If the requested equipement point conflicts with another harvest, booked by another
-    there should only be an available equipment point if conflicting
-    harvests are not scheduled or ready
+    If both the requested start and end time is during
+    another reservation, there should be no available equipment
+    points.
     """
 
     harvest.equipment_reserved.set([equipment])
     points = get_available_equipment_points(
-        harvest.start_date - timedelta(minutes=30),
-        harvest.end_date + timedelta(minutes=30),
+        start.replace(hour=14),
+        end.replace(hour=16),
         None,
     )
+
+    print(harvest.start_date)
+    print(harvest.start_date + timedelta(hours=2))
 
     if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
         assert points.count() == 0
@@ -148,8 +160,8 @@ def test_available_equipment_points_around(db, harvest, equipment) -> None:
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
 def test_available_equipment_points_same_dates(db, harvest, equipment) -> None:
     """
-    There should only be an available equipment point if concurrent harvests
-    are not scheduled or ready
+    If the requested times are at the same time as another reservation,
+    there should be no available equipment points.
     """
 
     harvest.equipment_reserved.set([equipment])
@@ -182,9 +194,9 @@ def test_available_equipment_points_conflict_when_checking_self(
     db, harvest, second_harvest, equipment
 ) -> None:
     """
-    If a harvest has already reserved an equipment point and we check if
-    a second harvest is conflicting with itself, that equipment point should
-    be unavailable be listed as available for itself.
+    If harvest one has already reserved an equipment point and we check if
+    a harvest two is conflicting with itself, that equipment point should
+    be unavailable.
     """
 
     harvest.equipment_reserved.set([equipment])
@@ -200,12 +212,15 @@ def test_available_equipment_points_conflict_when_checking_self(
 def test_available_equipment_points_after(db, harvest, equipment) -> None:
     """
     There should be an available equipment point if all
-    other harvests have passed
+    other reservations are in the past.
     """
 
     harvest.equipment_reserved.set([equipment])
-    delta = timedelta(hours=4)
-    points = get_available_equipment_points(harvest.start_date + delta, harvest.end_date + delta, None)
+    points = get_available_equipment_points(
+        start.replace(hour=20),
+        end.replace(hour=22),
+        None,
+    )
 
     assert points.count() == 1
 
@@ -215,12 +230,15 @@ def test_available_equipment_points_after(db, harvest, equipment) -> None:
 def test_available_equipment_points_before(db, harvest, equipment) -> None:
     """
     There should be an available equipment point if the next
-    harvest if further then the alloted buffer
+    reservation if further then the alloted buffer
     """
 
     harvest.equipment_reserved.set([equipment])
-    delta = timedelta(hours=4)
-    points = get_available_equipment_points(harvest.start_date - delta, harvest.end_date - delta, None)
+    points = get_available_equipment_points(
+        start.replace(hour=8),
+        end.replace(hour=10),
+        None,
+    )
 
     assert points.count() == 1
 
@@ -229,13 +247,15 @@ def test_available_equipment_points_before(db, harvest, equipment) -> None:
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
 def test_available_equipment_points_buffer_after(db, harvest, equipment) -> None:
     """
-    There should be no available equipment points right after
-    a scheduled or ready harvest
+    There should be no available equipment points right after a reservation.
     """
 
     harvest.equipment_reserved.set([equipment])
-    delta = timedelta(hours=2)
-    points = get_available_equipment_points(harvest.start_date + delta, harvest.end_date + delta, None)
+    points = get_available_equipment_points(
+        start.replace(hour=18),
+        end.replace(hour=20),
+        None,
+    )
 
     if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
         assert points.count() == 0
@@ -247,13 +267,16 @@ def test_available_equipment_points_buffer_after(db, harvest, equipment) -> None
 @pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
 def test_available_equipment_points_buffer_before(db, harvest, equipment) -> None:
     """
-    There should be no available equipment points right before
-    a scheduled or ready harvest
+    There should be no available equipment points right before a reservation
     """
 
     harvest.equipment_reserved.set([equipment])
-    delta = timedelta(hours=2)
-    points = get_available_equipment_points(harvest.start_date + delta, harvest.end_date + delta, None)
+
+    points = get_available_equipment_points(
+        start.replace(hour=8),
+        end.replace(hour=12),
+        None,
+    )
 
     if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
         assert points.count() == 0
@@ -272,15 +295,58 @@ def test_available_equipment_points_buffer_with_parse_naive_datetime(
     """
 
     harvest.equipment_reserved.set([equipment])
-    delta = timedelta(hours=1)
 
     end_str = harvest.end_date.replace(tzinfo=None).strftime(settings.DATETIME_INPUT_FORMATS[0])
     end = parse_naive_datetime(end_str, settings.DATETIME_INPUT_FORMATS[0])
     assert end is not None
 
-    points = get_available_equipment_points(end + delta, end + delta + delta, None)
+    points = get_available_equipment_points(end.replace(hour=13), end.replace(hour=14), None)
 
     if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
         assert points.count() == 0
     else:
         assert points.count() == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
+@pytest.mark.parametrize("second_harvest", Harvest.Status, indirect=True)
+def test_available_equipment_points_date_change_after_reservation(
+    db, harvest, second_harvest, equipment
+) -> None:
+    """
+    If two harvests reserve an equipment point at different times,
+    the second one should not be able to change it's time
+    to the first one without abandonning it's reservation.
+    """
+
+    harvest.equipment_reserved.set([equipment])
+    second_harvest.start_date = start.replace(day=1)
+    second_harvest.end_date = end.replace(day=1)
+
+    before_change_points = get_available_equipment_points(
+        start,
+        end,
+        second_harvest,
+    )
+
+    if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
+        assert before_change_points.count() == 0
+    else:
+        assert before_change_points.count() == 1
+
+    second_harvest.equipment_reserved.set([equipment])
+
+    second_harvest.start_date = start.replace(day=2)
+    second_harvest.end_date = end.replace(day=2)
+
+    after_change_points = get_available_equipment_points(
+        start,
+        end,
+        second_harvest,
+    )
+
+    if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
+        assert after_change_points.count() == 0
+    else:
+        assert after_change_points.count() == 1

--- a/saskatoon/unittests/member/test_utils.py
+++ b/saskatoon/unittests/member/test_utils.py
@@ -5,7 +5,7 @@ import hypothesis.strategies as st
 
 from django.conf import settings
 from sitebase.utils import parse_naive_datetime
-from member.utils import available_equipment_points
+from member.utils import get_available_equipment_points
 from harvest.models import Harvest, Equipment, EquipmentType
 from member.models import Organization, Country, State, City, Neighborhood
 
@@ -70,7 +70,7 @@ def test_available_equipment_points_fuzz() -> None:
     )
 
     cases = deal.cases(
-        func=available_equipment_points,
+        func=get_available_equipment_points,
         kwargs=dict(start=date_strat, end=date_strat, harvest=st.just(None)),
     )
 
@@ -88,7 +88,7 @@ def test_available_equipment_points_end_during(db, harvest, equipment) -> None:
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = available_equipment_points(
+    points = get_available_equipment_points(
         harvest.start_date - timedelta(hours=5),
         harvest.end_date - timedelta(hours=1),
         None,
@@ -110,9 +110,31 @@ def test_available_equipment_points_start_during(db, harvest, equipment) -> None
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = available_equipment_points(
+    points = get_available_equipment_points(
         harvest.start_date + timedelta(hours=1),
         harvest.end_date + timedelta(hours=5),
+        None,
+    )
+
+    if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
+        assert points.count() == 0
+    else:
+        assert points.count() == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("harvest", Harvest.Status, indirect=True)
+def test_available_equipment_points_around(db, harvest, equipment) -> None:
+    """
+    If the requested equipement point conflicts with another harvest, booked by another
+    there should only be an available equipment point if conflicting
+    harvests are not scheduled or ready
+    """
+
+    harvest.equipment_reserved.set([equipment])
+    points = get_available_equipment_points(
+        harvest.start_date - timedelta(minutes=30),
+        harvest.end_date + timedelta(minutes=30),
         None,
     )
 
@@ -131,7 +153,7 @@ def test_available_equipment_points_same_dates(db, harvest, equipment) -> None:
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = available_equipment_points(harvest.start_date, harvest.end_date, None)
+    points = get_available_equipment_points(harvest.start_date, harvest.end_date)
 
     if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
         assert points.count() == 0
@@ -148,7 +170,7 @@ def test_available_equipment_points_no_conflict_with_self(db, harvest, equipment
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = available_equipment_points(harvest.start_date, harvest.end_date, harvest)
+    points = get_available_equipment_points(harvest.start_date, harvest.end_date, harvest)
 
     assert points.count() == 1
 
@@ -166,7 +188,7 @@ def test_available_equipment_points_conflict_when_checking_self(
     """
 
     harvest.equipment_reserved.set([equipment])
-    points = available_equipment_points(
+    points = get_available_equipment_points(
         second_harvest.start_date, second_harvest.end_date, second_harvest
     )
 
@@ -183,7 +205,7 @@ def test_available_equipment_points_after(db, harvest, equipment) -> None:
 
     harvest.equipment_reserved.set([equipment])
     delta = timedelta(hours=4)
-    points = available_equipment_points(harvest.start_date + delta, harvest.end_date + delta, None)
+    points = get_available_equipment_points(harvest.start_date + delta, harvest.end_date + delta, None)
 
     assert points.count() == 1
 
@@ -198,7 +220,7 @@ def test_available_equipment_points_before(db, harvest, equipment) -> None:
 
     harvest.equipment_reserved.set([equipment])
     delta = timedelta(hours=4)
-    points = available_equipment_points(harvest.start_date - delta, harvest.end_date - delta, None)
+    points = get_available_equipment_points(harvest.start_date - delta, harvest.end_date - delta, None)
 
     assert points.count() == 1
 
@@ -213,7 +235,7 @@ def test_available_equipment_points_buffer_after(db, harvest, equipment) -> None
 
     harvest.equipment_reserved.set([equipment])
     delta = timedelta(hours=2)
-    points = available_equipment_points(harvest.start_date + delta, harvest.end_date + delta, None)
+    points = get_available_equipment_points(harvest.start_date + delta, harvest.end_date + delta, None)
 
     if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
         assert points.count() == 0
@@ -231,7 +253,7 @@ def test_available_equipment_points_buffer_before(db, harvest, equipment) -> Non
 
     harvest.equipment_reserved.set([equipment])
     delta = timedelta(hours=2)
-    points = available_equipment_points(harvest.start_date + delta, harvest.end_date + delta, None)
+    points = get_available_equipment_points(harvest.start_date + delta, harvest.end_date + delta, None)
 
     if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
         assert points.count() == 0
@@ -256,7 +278,7 @@ def test_available_equipment_points_buffer_with_parse_naive_datetime(
     end = parse_naive_datetime(end_str, settings.DATETIME_INPUT_FORMATS[0])
     assert end is not None
 
-    points = available_equipment_points(end + delta, end + delta + delta, None)
+    points = get_available_equipment_points(end + delta, end + delta + delta, None)
 
     if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
         assert points.count() == 0

--- a/saskatoon/unittests/member/test_utils.py
+++ b/saskatoon/unittests/member/test_utils.py
@@ -56,7 +56,6 @@ def equipment(db) -> Equipment:
     return equipment
 
 
-"""
 @pytest.mark.django_db
 def test_available_equipment_points_fuzz() -> None:
     start_strat = st.datetimes(
@@ -73,7 +72,7 @@ def test_available_equipment_points_fuzz() -> None:
             max_value=datetime.max,
             allow_imaginary=True,
         ),
-     )
+    )
 
     cases = deal.cases(
         func=get_available_equipment_points,
@@ -82,7 +81,7 @@ def test_available_equipment_points_fuzz() -> None:
 
     for case in cases:
         case()
-"""
+
 
 # For all cases, we assume that harvests can only reserve an equipment point
 # if they are scheduled or ready and that all equipment point reservations for
@@ -104,7 +103,7 @@ def test_available_equipment_points_end_during(db, harvest, equipment) -> None:
         None,
     )
 
-    if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
+    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
         assert points.count() == 0
     else:
         assert points.count() == 1
@@ -125,7 +124,7 @@ def test_available_equipment_points_start_during(db, harvest, equipment) -> None
         None,
     )
 
-    if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
+    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
         assert points.count() == 0
     else:
         assert points.count() == 1
@@ -150,7 +149,7 @@ def test_available_equipment_points_around(db, harvest, equipment) -> None:
     print(harvest.start_date)
     print(harvest.start_date + timedelta(hours=2))
 
-    if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
+    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
         assert points.count() == 0
     else:
         assert points.count() == 1
@@ -167,7 +166,7 @@ def test_available_equipment_points_same_dates(db, harvest, equipment) -> None:
     harvest.equipment_reserved.set([equipment])
     points = get_available_equipment_points(harvest.start_date, harvest.end_date)
 
-    if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
+    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
         assert points.count() == 0
     else:
         assert points.count() == 1
@@ -257,7 +256,7 @@ def test_available_equipment_points_buffer_after(db, harvest, equipment) -> None
         None,
     )
 
-    if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
+    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
         assert points.count() == 0
     else:
         assert points.count() == 1
@@ -278,7 +277,7 @@ def test_available_equipment_points_buffer_before(db, harvest, equipment) -> Non
         None,
     )
 
-    if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
+    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
         assert points.count() == 0
     else:
         assert points.count() == 1
@@ -302,7 +301,7 @@ def test_available_equipment_points_buffer_with_parse_naive_datetime(
 
     points = get_available_equipment_points(end.replace(hour=13), end.replace(hour=14), None)
 
-    if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
+    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
         assert points.count() == 0
     else:
         assert points.count() == 1
@@ -317,7 +316,7 @@ def test_available_equipment_points_date_change_after_reservation(
     """
     If two harvests reserve an equipment point at different times,
     the second one should not be able to change it's time
-    to the first one without abandonning it's reservation.
+    to the first one without abandoning it's reservation.
     """
 
     harvest.equipment_reserved.set([equipment])
@@ -330,7 +329,7 @@ def test_available_equipment_points_date_change_after_reservation(
         second_harvest,
     )
 
-    if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
+    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
         assert before_change_points.count() == 0
     else:
         assert before_change_points.count() == 1
@@ -346,7 +345,7 @@ def test_available_equipment_points_date_change_after_reservation(
         second_harvest,
     )
 
-    if harvest.status in [Harvest.Status.SCHEDULED, Harvest.Status.READY]:
+    if harvest.status in Harvest.ALLOWED_TO_RESERVE:
         assert after_change_points.count() == 0
     else:
         assert after_change_points.count() == 1


### PR DESCRIPTION
Fixes #670 

1. Logic did not account for the case where another harvests "surrounds" the requested time range:     `harvest_i_start`  <=  `requested_start`  < `requested_end`  <= `harvest_i_end`

2. The code responsible to prevent a harvest reservation to conflict with itself:
```
       # We need to exclude the present harvest from the results
        # so it doesnt conflict with itself
        id = getattr(harvest, "pk", None)
        not_itself = ~Q(harvest__pk=id)
```
made it impossible to detect conflicts with other harvest for the same equipment point because the reserved equipment was getting  excluded from the query (not simply the harvest <-> equipment relationship) so other harvests reserving it would not be part for the conflicting_orgs queryset