### PR TITLE
Fix public announcement box size

### DIFF
--- a/saskatoon/sitebase/static/css/style.css
+++ b/saskatoon/sitebase/static/css/style.css
@@ -2884,6 +2884,10 @@ hr {
 /*----------------------------------------*/
 /*  35.  Form Element CSS
 /*----------------------------------------*/
+.vLargeTextField {
+	height: auto;
+}
+
 .nk-int-st input[type="text"], .nk-int-st textarea, .nk-int-st [type="number"], .nk-int-st [type="password"]{
 	box-shadow: none;
     border-top: 0px solid #ccc;


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please fill out the necessary sections, and delete unused ones.
-->
Fixes #656 
----------
## Type of change:
- [x] Bug fix (change which fixes an issue).
----------
## What's Changed:

Large inputs where being set at the same
size as one line inputs.

--------
## Affected URLs:

`/harvest/update/x`
`/harvest/create/`

And any other page that uses a multi line form input.
