### PR TITLE
chore: harmonize breadcombs + view/edit links in table rows

### DIFF
--- a/saskatoon/harvest/models.py
+++ b/saskatoon/harvest/models.py
@@ -686,7 +686,7 @@ class Harvest(models.Model):
         title = ", ".join(self.get_fruits())
         neighborhood_name = self.get_neighborhood()
         if neighborhood_name != "Other":
-            title += f" @ {neighborhood_name}"
+            title += f" — {neighborhood_name}"
         return title
 
     def is_urgent(self) -> bool:

--- a/saskatoon/sitebase/locale/fr/LC_MESSAGES/django.po
+++ b/saskatoon/sitebase/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-05 21:43+0000\n"
+"POT-Creation-Date: 2026-05-06 01:14-0400\n"
 "PO-Revision-Date: 2025-06-12 13:46-0518\n"
 "Last-Translator: Anonymous User\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -147,7 +147,7 @@ msgid "Corps (fr)"
 msgstr "Contenu (fr)"
 
 #: sitebase/models.py:265
-#: sitebase/templates/app/detail_views/harvest/about.html:54
+#: sitebase/templates/app/detail_views/harvest/about.html:60
 #: sitebase/templates/app/detail_views/organization/contact.html:46
 #: sitebase/templates/app/detail_views/property/contact.html:63
 msgid "Email"
@@ -177,7 +177,7 @@ msgid "Successfully sent"
 msgstr "Envoyé avec succès"
 
 #: sitebase/models.py:300
-#: sitebase/templates/app/detail_views/organization/harvest_table.html:24
+#: sitebase/templates/app/detail_views/organization/harvest_table.html:28
 #: sitebase/templates/app/detail_views/property/harvest_table.html:51
 msgid "Date"
 msgstr "Date"
@@ -266,7 +266,7 @@ msgid "login"
 msgstr "Connexion"
 
 #: sitebase/templates/app/base/header.html:111
-#: sitebase/templates/app/detail_views/harvest/about.html:60
+#: sitebase/templates/app/detail_views/harvest/about.html:66
 #: sitebase/templates/app/detail_views/organization/contact.html:57
 #: sitebase/templates/app/detail_views/property/contact.html:78
 msgid "Language"
@@ -324,7 +324,7 @@ msgstr "Dates de maturité des fruits"
 #: sitebase/templates/app/calendar/ready-modal.html:25
 #: sitebase/templates/app/calendar/scheduled-modal.html:25
 #: sitebase/templates/app/calendar/succeeded-modal.html:25
-#: sitebase/templates/app/detail_views/harvest/about.html:18
+#: sitebase/templates/app/detail_views/harvest/about.html:24
 #: sitebase/templates/app/detail_views/harvest/equipment.html:15
 #: sitebase/templates/app/detail_views/harvest/status.html:19
 #: sitebase/templates/app/forms/participation_create_form.html:42
@@ -439,7 +439,7 @@ msgstr "n'aura pas lieu"
 #: sitebase/templates/app/calendar/legend.html:23
 #: sitebase/templates/app/calendar/orphan-modal.html:31
 #: sitebase/templates/app/detail_views/property/harvest_row.html:9
-#: sitebase/templates/app/list_views/property/data_row.html:52
+#: sitebase/templates/app/list_views/property/data_row.html:61
 msgid "Orphan"
 msgstr "Orpheline"
 
@@ -508,18 +508,19 @@ msgstr "INSTRUCTIONS"
 msgid "Public announcement"
 msgstr "Annonce publique"
 
-#: sitebase/templates/app/detail_views/harvest/about.html:25
+#: sitebase/templates/app/detail_views/harvest/about.html:31
 msgid "Property information"
 msgstr "Informations de la propriété"
 
-#: sitebase/templates/app/detail_views/harvest/about.html:36
+#: sitebase/templates/app/detail_views/harvest/about.html:42
 #: sitebase/templates/app/detail_views/organization/address.html:5
 #: sitebase/templates/app/detail_views/property/about.html:10
 #: sitebase/templates/app/forms/property_create_form.html:48
+#: sitebase/templates/app/list_views/property/view.html:12
 msgid "Address"
 msgstr "Adresse"
 
-#: sitebase/templates/app/detail_views/harvest/about.html:43
+#: sitebase/templates/app/detail_views/harvest/about.html:49
 #: sitebase/templates/app/detail_views/harvest/distribution/recipient_select.html:5
 #: sitebase/templates/app/detail_views/property/contact.html:8
 #: sitebase/templates/app/detail_views/property/similar_table.html:17
@@ -529,13 +530,13 @@ msgstr "Adresse"
 msgid "Owner"
 msgstr "Propriétaire"
 
-#: sitebase/templates/app/detail_views/harvest/about.html:48
+#: sitebase/templates/app/detail_views/harvest/about.html:54
 #: sitebase/templates/app/detail_views/organization/contact.html:35
 #: sitebase/templates/app/detail_views/property/contact.html:50
 msgid "Phone"
 msgstr "Téléphone"
 
-#: sitebase/templates/app/detail_views/harvest/breadcomb.html:22
+#: sitebase/templates/app/detail_views/harvest/breadcomb.html:42
 msgid "Edit Harvest"
 msgstr "Éditer la récolte"
 
@@ -668,7 +669,7 @@ msgid "Weight"
 msgstr "Poids"
 
 #: sitebase/templates/app/detail_views/harvest/distribution/view.html:21
-#: sitebase/templates/app/list_views/organization/data_row.html:12
+#: sitebase/templates/app/list_views/organization/data_row.html:15
 msgid "Delete"
 msgstr "Effacer"
 
@@ -758,25 +759,25 @@ msgstr "Téléphone de l'Organisation"
 msgid "Modify Equipment"
 msgstr "Modifier l'Équipement"
 
-#: sitebase/templates/app/detail_views/organization/equipment_table.html:10
-msgid "Available Equipment"
+#: sitebase/templates/app/detail_views/organization/equipment_table.html:11
+msgid "Available equipment"
 msgstr "Équipement Disponible"
 
-#: sitebase/templates/app/detail_views/organization/equipment_table.html:15
+#: sitebase/templates/app/detail_views/organization/equipment_table.html:17
 msgid "New Equipment"
 msgstr "Nouvel Équipement"
 
-#: sitebase/templates/app/detail_views/organization/equipment_table.html:25
+#: sitebase/templates/app/detail_views/organization/equipment_table.html:28
 msgid "Type"
 msgstr "Type"
 
-#: sitebase/templates/app/detail_views/organization/equipment_table.html:26
+#: sitebase/templates/app/detail_views/organization/equipment_table.html:29
 #: sitebase/templates/app/list_views/equipment/data_table.html:13
 #: sitebase/templates/app/list_views/equipment/view.html:14
 msgid "Count"
 msgstr "Quantité"
 
-#: sitebase/templates/app/detail_views/organization/equipment_table.html:27
+#: sitebase/templates/app/detail_views/organization/equipment_table.html:30
 #: sitebase/templates/app/list_views/equipment/data_table.html:14
 #: sitebase/templates/app/list_views/equipment/view.html:15
 #: sitebase/templates/app/participation_list.html:19
@@ -792,19 +793,23 @@ msgstr "Description"
 msgid "Beneficiary"
 msgstr "Bénéficiaire"
 
-#: sitebase/templates/app/detail_views/organization/harvest_table.html:10
+#: sitebase/templates/app/detail_views/organization/harvest_table.html:11
 msgid "Upcoming Reservations"
 msgstr "Réservations à venir"
 
-#: sitebase/templates/app/detail_views/organization/harvest_table.html:23
+#: sitebase/templates/app/detail_views/organization/harvest_table.html:16
+msgid "Past reservations"
+msgstr "Réservations passées"
+
+#: sitebase/templates/app/detail_views/organization/harvest_table.html:27
 msgid "PickLeader"
 msgstr "Chef.fe de cueillette"
 
-#: sitebase/templates/app/detail_views/organization/harvest_table.html:25
+#: sitebase/templates/app/detail_views/organization/harvest_table.html:29
 msgid "Start"
 msgstr "Début"
 
-#: sitebase/templates/app/detail_views/organization/harvest_table.html:26
+#: sitebase/templates/app/detail_views/organization/harvest_table.html:30
 msgid "End"
 msgstr "Fin"
 
@@ -979,7 +984,7 @@ msgstr "Propriétés similaires"
 #: sitebase/templates/app/detail_views/property/similar_table.html:14
 #: sitebase/templates/app/forms/participation_manage_form.html:19
 #: sitebase/templates/app/list_views/harvest/view.html:14
-#: sitebase/templates/app/list_views/property/view.html:12
+#: sitebase/templates/app/list_views/property/view.html:11
 #: sitebase/templates/app/participation_list.html:20
 msgid "Property"
 msgstr "Propriété"
@@ -1076,7 +1081,6 @@ msgid "Search"
 msgstr "Rechercher"
 
 #: sitebase/templates/app/list_views/community/data_row.html:17
-#: sitebase/templates/app/list_views/organization/data_row.html:11
 msgid "Are you really sure you want to delete this actor?"
 msgstr "Êtes-vous certain(e) de vouloir effacer ce contact?"
 
@@ -1145,10 +1149,15 @@ msgstr "Dialogue de détails de Bénéficiaire"
 msgid "This organization accepts fruit donations"
 msgstr "Cet organisme accepte les dons de fruits"
 
-#: sitebase/templates/app/list_views/organization/data_row.html:17
-#: sitebase/templates/app/list_views/organization/data_row.html:39
+#: sitebase/templates/app/list_views/organization/data_row.html:7
+#: sitebase/templates/app/list_views/property/data_row.html:7
+msgid "View"
+msgstr "Voir"
+
+#: sitebase/templates/app/list_views/organization/data_row.html:27
+#: sitebase/templates/app/list_views/organization/data_row.html:42
 msgid "Edit"
-msgstr "Éditer"
+msgstr "Modifier"
 
 #: sitebase/templates/app/list_views/organization/equipment_modal.html:6
 msgid "Equipment point details dialog"

--- a/saskatoon/sitebase/static/css/harvest-details.css
+++ b/saskatoon/sitebase/static/css/harvest-details.css
@@ -3,27 +3,11 @@
 }
 
 .main-content {
-	.container {
-		& > header {
-			margin-top: var(--saskatoon-gap);
-			padding: 20px;
-			margin-bottom: var(--saskatoon-gap);
-
-			i {
-				color: #440bd4;
-			}
-		}
-	}
-
 	header {
 		background-color: #e7e0f9;
 		display: grid;
 		grid-template-columns: auto;
 		gap: var(--saskatoon-gap);
-
-		h1 {
-			margin: 0;
-		}
 
 		a {
 			margin-top: auto;
@@ -80,14 +64,6 @@
 	td {
 		font-weight: bold;
 		text-align: right;
-	}
-}
-
-@media (min-width: 650px) {
-	.container {
-		& > header {
-			grid-template-columns: auto min-content;
-		}
 	}
 }
 

--- a/saskatoon/sitebase/static/css/style.css
+++ b/saskatoon/sitebase/static/css/style.css
@@ -4701,17 +4701,15 @@ body.box-layout {
 	display:flex;
 }
 .breadcomb-icon i{
-	font-size: 20px;
+	font-size: 30px;
     color: #440bd4;
     padding: 15px;
+    margin-right: 10px;
     position: relative;
-    border-radius: 50%;
-    border-right: 1px solid #ccc;
-    border-top: 1px solid #ccc;
 	display:block;
 }
 .breadcomb-list{
-	padding:20px 20px;
+	padding: 20px;
 	background:#e7e0f9;
 }
 .breadcomb-ctn {
@@ -4722,8 +4720,13 @@ body.box-layout {
 	color:#333;
 }
 .breadcomb-ctn h1{
-    padding-top:10px;
+    padding-top: 0;
 }
+
+.breadcomb-ctn h4{
+	margin-bottom: 0;
+}
+
 .breadcomb-ctn p{
 	font-size:14px;
 	color:#333;

--- a/saskatoon/sitebase/templates/app/base/menu-tabs.html
+++ b/saskatoon/sitebase/templates/app/base/menu-tabs.html
@@ -9,7 +9,7 @@
     <a href="{% url 'harvest-list' %}?season={% now 'Y' %}"><i class="fa fa-shopping-basket"></i> {% translate "Harvests" %}</a>
 </li>
 <li class="{% if request.resolver_match.url_name == 'property-list' %}active{% endif %}">
-    <a href="{% url 'property-list' %}?is_active=true"><i class="glyphicon glyphicon-tree-deciduous"></i> {% translate "Properties" %}</a>
+    <a href="{% url 'property-list' %}?is_active=true"><i class="fa fa-house"></i> {% translate "Properties" %}</a>
 </li>
 <li class="{% if request.resolver_match.url_name == 'organization-list' or request.resolver_match.url_name == 'organization-map' %}active{% endif %}">
     <a href="{% url 'organization-list' %}?type=1"><i class="fa fa-gift"></i> {% translate "Beneficiaries" %}</a>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/about.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/about.html
@@ -4,7 +4,8 @@
 <div class="property-and-announcements">
     <section>
         <h2>{% trans "Public announcement" %}</h2>
-        <h3>
+        <br>
+        <h4>
             {% if LANG == "en" %}
                 {% for tree in trees %}
                     {{ tree.name_en }}
@@ -16,14 +17,12 @@
                     {% if not forloop.last %},{% endif %}
                 {% endfor %}
             {% endif %}
-            @ {{ property.neighborhood }}
-        </h3>
-        <br>
+            — {{ property.neighborhood }}
+        </h4>
         {% if status != "orphan" and status != "adopted" %}
             <h4>{{ start_date }}</h4>
             <h5>{{ start_time }} {% trans "to" %} {{ end_time }}</h5>
         {% endif %}
-        <br>
         {{ about | safe }}
     </section>
     <section>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/about.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/about.html
@@ -6,9 +6,15 @@
         <h2>{% trans "Public announcement" %}</h2>
         <h3>
             {% if LANG == "en" %}
-                {% for tree in trees %}{{ tree.name_en }} {{ tree.fruit_icon|default:"" }},{% endfor %}
+                {% for tree in trees %}
+                    {{ tree.name_en }}
+                    {% if not forloop.last %},{% endif %}
+                {% endfor %}
             {% else %}
-                {% for tree in trees %}{{ tree.name_fr }} {{ tree.fruit_icon|default:"" }},{% endfor %}
+                {% for tree in trees %}
+                    {{ tree.name_fr }}
+                    {% if not forloop.last %},{% endif %}
+                {% endfor %}
             {% endif %}
             @ {{ property.neighborhood }}
         </h3>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/breadcomb.html
@@ -23,7 +23,7 @@
                                 {% endif %}
                                 {% if not forloop.last %},{% endif %}
                             {% endfor %}
-                            @
+                            —
                             {{ property.address }}
                         </h1>
                         <h4>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/breadcomb.html
@@ -2,24 +2,49 @@
 {% load static %}
 {% load auth_users %}
 {% get_current_language as LANG %}
-<header>
-    <h1>
-        <i class="fa fa-shopping-basket notika-text-primary"></i>#{{ id }}:
-        {% for t in trees %}
-            {% if LANG == "en" %}
-                {{ t.name_en }}
-            {% else %}
-                {{ t.name_fr }}
-            {% endif %}
-            {{ t.fruit_icon|default:"" }},
-        {% endfor %}
-        {{ property.address }},
-        {{ property.neighborhood }}
-    </h1>
-    {% if user|is_core_or_admin or user|is_pickleader:id %}
-        <a class="btn btn-primary notika-btn-primary"
-           href="{% url 'harvest-update' id %}">
-            <i class="fa fa-pencil"></i> {% trans "Edit Harvest" %}
-        </a>
-    {% endif %}
-</header>
+
+<div class="breadcomb-area">
+    <div class="breadcomb-list">
+        <div class="row">
+            <div class="col-xs-10">
+                <div class="breadcomb-wp">
+                    <div class="breadcomb-icon">
+                        <i class="fa fa-shopping-basket notika-text-primary"></i>
+                    </div>
+                    <div class="breadcomb-ctn">
+                        <h1>
+                            #{{ id }}
+                            &nbsp;
+                            {%for t in trees %}
+                                {% if LANG == "en" %}
+                                    {{ t.name_en }}
+                                {% else %}
+                                    {{ t.name_fr }}
+                                {% endif %}
+                                {% if not forloop.last %},{% endif %}
+                            {% endfor %}
+                            @
+                            {{ property.address }}
+                        </h1>
+                        <h4>
+                            {{ property.neighborhood }}
+                        </h4>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-xs-2">
+                <div class="breadcomb-report">
+                    {% if user|is_core_or_admin or user|is_pickleader:id %}
+                        <a href="{% url 'harvest-update' id %}">
+                            <button title="Edit harvest" class="btn">
+                                <i class="fa fa-pencil"></i>&nbsp;
+                                {% trans "Edit Harvest" %}
+                            </button>
+                        </a>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/data_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/data_row.html
@@ -102,7 +102,7 @@
         </a>
         {% else %}
         <a href="{% url 'participation-update' r.id %}">
-            <i class="fa fa-pencil"></i>
+            <i class="fa fa-eye"></i>
         </a>
         {% endif %}
     </td>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/breadcomb.html
@@ -1,41 +1,39 @@
 {% load i18n %}
 {% load static %}
+
 <div class="breadcomb-area">
-    <div class="container">
+    <div class="breadcomb-list">
         <div class="row">
-            <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
-                <div class="breadcomb-list">
-                    <div class="row">
-                        <div class="col-lg-10 col-md-10 col-sm-10 col-xs-12">
-                            <div class="breadcomb-wp">
-                                <div class="breadcomb-icon">
-                                    {% if is_equipment_point %}
-                                        <i class="fa fa-scissors"></i>
-                                    {% else %}
-                                        <i class="fa fa-gift"></i>
-                                    {% endif %}
-                                </div>
-                                <div class="breadcomb-ctn">
-                                    <h1>
-                                        {{ civil_name }}
-                                    </h1>
-                                    <h2>
-                                        {{ neighborhood.name }}
-                                    </h2>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
-                            <div class="breadcomb-report">
-                                {% if perms.member.change_organization %}
-                                    <a href="{% url 'organization-update' actor_id %}">
-                                        <button title="Edit Organization" class="btn">
-                                            {% trans "Edit Organization" %}</button>
-                                    </a>
-                                {% endif %}
-                            </div>
-                        </div>
+            <div class="col-xs-10">
+                <div class="breadcomb-wp">
+                    <div class="breadcomb-icon">
+                        {% if is_equipment_point %}
+                            <i class="fa fa-scissors"></i>
+                        {% else %}
+                            <i class="fa fa-gift"></i>
+                        {% endif %}
                     </div>
+                    <div class="breadcomb-ctn">
+                        <h1>
+                            {{ civil_name }}
+                        </h1>
+                        <h4>
+                            {{ neighborhood.name }}
+                        </h4>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-xs-2">
+                <div class="breadcomb-report">
+                    {% if perms.member.change_organization %}
+                        <a href="{% url 'organization-update' actor_id %}">
+                            <button title="Edit Organization" class="btn">
+                                <i class="fa fa-pencil"></i>&nbsp;
+                                {% trans "Edit Organization" %}
+                            </button>
+                        </a>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/equipment_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/equipment_row.html
@@ -1,9 +1,12 @@
 {% load i18n %}
 {% load static %}
 <tr>
-  <td>{{ item.id }}
+  <td># {{ item.id }}
     {% if perms.harvest.change_equipment %}
-    <a href="{% url 'equipment-update' item.id %}" title="{% trans 'Modify Equipment' %} {{ item.id }}"><i class="fa fa-pencil"></i></a>
+        <a href="{% url 'equipment-update' item.id %}" title="{% trans 'Modify Equipment' %} {{ item.id }}">
+            &nbsp;
+            <small><i class="fa fa-pencil"></i></small>
+        </a>
     {% endif %}
   </td>
   <td>
@@ -17,7 +20,6 @@
     {{item.count}}
   </td>
   <td>
-    <span>{{ item.description }}
-    </span><br>
+    <span>{{ item.description }}</span><br>
   </td>
 </tr>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/equipment_table.html
@@ -6,16 +6,19 @@
       <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
         <div class="data-table-list">
           <div class="table-responsive">
-            <div>
-              <h4>{% trans "Available Equipment" %}</h4>
-              {% if perms.harvest.add_equipment %}
-              <a href="{% url 'equipment-create' %}?aid={{ actor_id }}">
-                <button title="New Equipment" class="btn btn-primary notika-btn-primary waves-effect">
-                  <i class="fa fa-plus"></i>
-                  {% trans "New Equipment" %}
-                </button>
-              </a>
-              {% endif %}
+            <div class="row">
+                <div class="col-xs-6">
+                    <h4>{% trans "Available equipment" %}</h4>
+                </div>
+                <div class="col-xs-6">
+                    {% if perms.harvest.add_equipment %}
+                    <a href="{% url 'equipment-create' %}?aid={{ actor_id }}" style="float: right">
+                        <button title="New Equipment" class="btn btn-primary notika-btn-primary waves-effect">
+                            <i class="fa fa-plus"></i> {% trans "New Equipment" %}
+                        </button>
+                    </a>
+                    {% endif %}
+                </div>
             </div>
             <br>
             <table class="table table-striped" id="data-table-basic">

--- a/saskatoon/sitebase/templates/app/detail_views/organization/harvest_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/harvest_row.html
@@ -3,7 +3,7 @@
 <tr>
   <td>
       <a href="{% url 'harvest-detail' harvest.id %}">
-          # {{ harvest.id }}&nbsp;
+          # {{ harvest.id }}&nbsp;<small><i class="fa fa-eye"></i></small>
       </a>
   </td>
   <td>

--- a/saskatoon/sitebase/templates/app/detail_views/organization/harvest_table.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/harvest_table.html
@@ -6,13 +6,17 @@
       <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
         <div class="data-table-list">
           <div class="table-responsive">
-            <div>
-              <h4> {% trans "Upcoming Reservations" %} </h4>
-
-            <a class="btn btn-primary notika-btn-primary waves-effect" href="{% url 'harvest-list' %}?date=past&has_equipment_point=on&equipment_point={{ actor_id }}">
-              See past reservations
-            </a>
-
+            <div class="row">
+                <div class="col-xs-6">
+                    <h4> {% trans "Upcoming Reservations" %} </h4>
+                </div>
+                <div class="col-xs-6">
+                    <a href="{% url 'harvest-list' %}?date=past&has_equipment_point=on&equipment_point={{ actor_id }}" style="float: right">
+                        <button title="Past reservations" class="btn btn-primary notika-btn-primary waves-effect">
+                        <i class="fa fa-eye"></i> &nbsp; {% trans "Past reservations" %}
+                        </button>
+                    </a>
+                </div>
             </div>
             <br>
 

--- a/saskatoon/sitebase/templates/app/detail_views/organization/view.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/view.html
@@ -5,9 +5,11 @@
 
 {% block content %}
 
+<div class="container">
 {% include 'app/detail_views/organization/breadcomb.html' %}
+</div>
 
-<div class="search-engine-area mg-t-30">
+<div class="search-engine-area">
   <div class="container">
     <div class="row">
       <div class="col-lg-4 col-md-6 col-sm-12 col-xs-12">
@@ -23,9 +25,11 @@
 </div>
 
 {% if is_equipment_point %}
+<div class="mg-b-15">
 <!-- FIXME: table does not render some elements surrounding the data e.g. search bar -->
     {% include 'app/detail_views/organization/equipment_table.html' %}
     {% include 'app/detail_views/organization/harvest_table.html' %}
+</div>
 {% endif %}
 
 {% endblock content %}

--- a/saskatoon/sitebase/templates/app/detail_views/property/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/breadcomb.html
@@ -9,7 +9,7 @@
                         <div class="col-lg-9 col-md-9 col-sm-9 col-xs-12">
                             <div class="breadcomb-wp">
                                 <div class="breadcomb-icon">
-                                    <i class="glyphicon glyphicon-tree-deciduous"></i>
+                                    <i class="fa fa-house"></i>
                                 </div>
                                 <div class="breadcomb-ctn">
                                     <h1>

--- a/saskatoon/sitebase/templates/app/detail_views/property/harvest_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/harvest_row.html
@@ -7,7 +7,7 @@
     <td>
         <a href='{% url "harvest-detail" harvest.id %}'>
             {% if harvest.pick_leader %}{% trans "Harvest" %}{% else %}{% trans "Orphan" %}{% endif %}
-            #{{ harvest.id }} &nbsp; <i class="fa fa-pencil"></i>
+            #{{ harvest.id }} &nbsp; <i class="fa fa-eye"></i>
         </a>
         {% if perms.harvest.delete_harvest %}
             &nbsp;

--- a/saskatoon/sitebase/templates/app/list_views/harvest/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/harvest/data_row.html
@@ -7,7 +7,7 @@
     <td>
         <a href="{% url 'harvest-detail' harvest.id %}">
             # {{ harvest.id }}&nbsp;
-            <small><i class="fa fa-pencil"></i></small>
+            <small><i class="fa fa-eye"></i></small>
         </a>
         {% if perms.harvest.delete_harvest %}
         &nbsp;&nbsp;

--- a/saskatoon/sitebase/templates/app/list_views/organization/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/organization/data_row.html
@@ -4,27 +4,30 @@
 
 <tr>
     <td>
-        {{ org.actor_id }}&nbsp;
+        <a href="{% url 'organization-detail' org.actor_id %}" title="{% trans 'View' %} {{ org.civil_name }}">
+        # {{ org.actor_id }}&nbsp;
+        <small><i class="fa fa-eye"></i></small>
+        </a>
         {% if perms.member.delete_actor %}
+            &nbsp;&nbsp;
             <small>
-                <a href="{% url 'admin:member_actor_delete' org.actor_id %}"
-                   onclick="return confirm('{% trans "Are you really sure you want to delete this actor?" %}');"
-                   title="{% trans 'Delete' %} {{ org.civil_name }}">
+                <a href="{% url 'admin:member_actor_delete' org.actor_id %}" onclick="return confirm('{% trans " Are you really sure
+                    you want to delete this actor?" %}');" title="{% trans 'Delete' %} {{ org.civil_name }}">
                     <i class="fa fa-trash text-danger"></i>
                 </a>
             </small>
-        {% endif %}            {% if perms.member.change_actor %}
-                <small><a href="{% url 'organization-update' org.actor_id %}" title="{% trans 'Edit' %} {{ org.civil_name }}">
-                    <i class="fa fa-pencil"></i>
-                </a></small>
-            {% endif %}
+        {% endif %}
 
     </td>
     <td>
         <span>
-            <b>
-              <a href="{% url 'organization-detail' org.actor_id %}">{{ org.civil_name }}</a>
-            </b>
+            <b>{{ org.civil_name }}</b>
+            {% if perms.member.change_actor %}
+                &nbsp;
+                <a href="{% url 'organization-update' org.actor_id %}"title="{% trans 'Edit' %} {{ org.civil_name }}">
+                    <small><i class="fa fa-pencil"></i></small>
+                </a>
+            {% endif %}
         </span>
         <br> <i class="fa fa-phone text-muted"></i>&nbsp; {{ org.phone }}
         {% if org.short_address %}

--- a/saskatoon/sitebase/templates/app/list_views/property/data_row.html
+++ b/saskatoon/sitebase/templates/app/list_views/property/data_row.html
@@ -4,19 +4,28 @@
 {% get_current_language as LANG %}
 <tr>
     <td>
-        {{ property.id }}
+        <a href="{% url 'property-detail' property.id %}" title="{% trans 'View' %} {{ property.title }}">
+        # {{ property.id }}&nbsp;
+        <small><i class="fa fa-eye"></i></small>
+        </a>
         {% if perms.harvest.delete_property %}
-        &nbsp;
-        <small>
-            <a href="{% url 'admin:harvest_property_delete' property.id %}" onclick="return confirm('{% trans " Are you
-                really sure you want to delete this property?" %}');">
-                <i class="fa fa-trash text-danger"></i>
-            </a>
-        </small>
+            &nbsp;
+            <small>
+                <a href="{% url 'admin:harvest_property_delete' property.id %}" onclick="return confirm('{% trans " Are you really
+                    sure you want to delete this property?" %}');">
+                    <i class="fa fa-trash text-danger"></i>
+                </a>
+            </small>
         {% endif %}
     </td>
     <td>
-        <a href="{% url 'property-detail' property.id %}">{{ property.title }} &nbsp; <i class="fa fa-pencil"></i></a>
+        <b>{{ property.title }}</b>
+        {% if perms.harvest.change_property %}
+            &nbsp;
+            <a href="{% url 'property-update' property.id %}">
+                <small><i class="fa fa-pencil"></i></small>
+            </a>
+        {% endif %}
     </td>
     <td>
         {{ property.neighborhood }}

--- a/saskatoon/sitebase/templates/app/list_views/property/view.html
+++ b/saskatoon/sitebase/templates/app/list_views/property/view.html
@@ -8,8 +8,8 @@
       <table class="table table-striped datatable-minimal">
         <thead>
             <tr>
-                <th class="col-xs-1">#</th>
-                <th class="col-xs-3">{% trans "Property" %}</th>
+                <th class="col-xs-1">{% trans "Property" %}</th>
+                <th class="col-xs-3">{% trans "Address" %}</th>
                 <th class="col-xs-1">{% trans "Borough" %}</th>
                 <th class="col-xs-1">{% trans "Status" %}</th>
                 <th class="col-xs-1">{% trans "Tree(s)" %}</th>


### PR DESCRIPTION
## Before

<img width="1459" height="874" alt="before-equipment-list" src="https://github.com/user-attachments/assets/1d41f634-1af6-4ba6-bade-d4415339bd8b" />
[1]

- Buttons location don't match other pages
- pencils are larger than in other pages
- missing margin above footer

___ 
<img width="1466" height="199" alt="before-harvest-breadcomb" src="https://github.com/user-attachments/assets/0cd6d4bd-6ca5-4f5b-888c-2568cd34c3a5" />
[2]

- Breadcomb height doesn't match other pages
- no padding around icon
- Edit button missing pencil

___
<img width="1460" height="223" alt="before-org-breadcomb" src="https://github.com/user-attachments/assets/218694fc-7663-4ac0-9700-f0e27bb97f97" />
[3]

- subtitle too large
- awkward bottom padding
- pencil missing in Edit button

___
<img width="495" height="354" alt="screenshot_2026-05-06_01:31:45" src="https://github.com/user-attachments/assets/a2782f8c-d467-4446-ac87-37323c1db3c3" />
[4]

- pencil clickable area is smaller than in other pages (should encompass the # id) 
- pencil actually edits the org (makes sense but not consistent with `#` column in other tables)

___
<img width="465" height="309" alt="screenshot_2026-05-06_01:30:42" src="https://github.com/user-attachments/assets/ba2fafef-ea91-4249-a44f-3b853c5bf9c4" />
[5]
- awkward heading sizes
- trailing comma in tree list


## After

<img width="1440" height="744" alt="after-equipment-list" src="https://github.com/user-attachments/assets/ec070c09-2e74-4e18-9a8c-3a3d796ed39c" />
[1]

___
<img width="1466" height="216" alt="after-harvest-breadcomb" src="https://github.com/user-attachments/assets/165ec0a7-cdaf-44f2-b98a-144a31e846a7" />
[2]

___
<img width="1471" height="215" alt="after-org-breadcomb" src="https://github.com/user-attachments/assets/f8d128b2-fa21-4ae2-809a-af76948c4665" />
[3]

___
<img width="390" height="353" alt="after-org-list" src="https://github.com/user-attachments/assets/c35314fb-7b63-4536-938a-21ffa1a2ceb3" />
[4]  -> clarified edit (pencil) vs view (eye) in list views

___
<img width="592" height="282" alt="screenshot_2026-05-06_01:29:48" src="https://github.com/user-attachments/assets/298e885b-f70f-4f3b-b867-c55155780b35" />
[5]