### PR TITLE
chore: improve users fixtures

### DIFF
--- a/saskatoon/fixtures/harvest-requestforparticipation.json
+++ b/saskatoon/fixtures/harvest-requestforparticipation.json
@@ -88,5 +88,20 @@
     "date_status_updated": "2026-07-25T23:00:03Z",
     "showed_up": null
   }
+},
+{
+  "model": "harvest.requestforparticipation",
+  "pk": 8,
+  "fields": {
+    "harvest": 4,
+    "person": 13,
+    "status": "pending",
+    "number_of_pickers": 1,
+    "comment": "J'apporterai quelques pêches à déguster!",
+    "notes": null,
+    "date_created": "2026-05-08T11:59:30.663Z",
+    "date_status_updated": null,
+    "showed_up": null
+  }
 }
 ]

--- a/saskatoon/fixtures/init
+++ b/saskatoon/fixtures/init
@@ -20,6 +20,7 @@ seq=(auth-group \
      member-neighborhood \
      member-state \
      member-country \
+     member-onboarding \
      member-actor \
      member-person \
      member-organization \

--- a/saskatoon/fixtures/member-actor.json
+++ b/saskatoon/fixtures/member-actor.json
@@ -63,5 +63,15 @@
   "model": "member.actor",
   "pk": 13,
   "fields": {}
+},
+{
+  "model": "member.actor",
+  "pk": 14,
+  "fields": {}
+},
+{
+  "model": "member.actor",
+  "pk": 15,
+  "fields": {}
 }
 ]

--- a/saskatoon/fixtures/member-authuser.json
+++ b/saskatoon/fixtures/member-authuser.json
@@ -14,7 +14,8 @@
     "is_active": true,
     "is_staff": true,
     "groups": [
-      3
+      3,
+      4
     ],
     "user_permissions": []
   }
@@ -63,7 +64,7 @@
   "model": "member.authuser",
   "pk": 5,
   "fields": {
-    "password": "pbkdf2_sha256$260000$x6u0VuwTbimW0Or07AA0Pz$Y3O+P8b9QPZSvDDgTS/+KE9gJX6o1C+4PC5Zv3n9Oqg=",
+    "password": "",
     "last_login": null,
     "is_superuser": false,
     "person": 1,
@@ -103,8 +104,8 @@
   "model": "member.authuser",
   "pk": 7,
   "fields": {
-    "password": "pbkdf2_sha256$260000$5Q49AEg1qHuIf9Ijtk23YY$41k91lHX/m8fEVopi22ZFrixcUBTtYI56GpyjkKH79Q=",
-    "last_login": "2026-01-24T15:27:24.183Z",
+    "password": "pbkdf2_sha256$600000$QYYe9epryqzrNGNFJ62V7x$1zpWIvEfIWW4KVFFfasVqSShjKMI6phq9jeDDErjygU=",
+    "last_login": "2026-05-08T11:55:14.028Z",
     "is_superuser": true,
     "person": 10,
     "has_temporary_password": false,
@@ -174,7 +175,49 @@
     "is_active": true,
     "is_staff": false,
     "groups": [
-      2
+      2,
+      4
+    ],
+    "user_permissions": []
+  }
+},
+{
+  "model": "member.authuser",
+  "pk": 11,
+  "fields": {
+    "password": "pbkdf2_sha256$600000$inQFnMH8U4kUqswGDKlGkq$ei3cFOYmKOx5IVXjWr0NXcCroqzcVrQVgVR8nM1mfV4=",
+    "last_login": "2022-05-13T11:55:14.028Z",
+    "is_superuser": false,
+    "person": 14,
+    "has_temporary_password": false,
+    "agreed_terms": false,
+    "email": "inactive@user.com",
+    "date_joined": "2022-05-08T02:44:56.046Z",
+    "is_active": false,
+    "is_staff": true,
+    "groups": [
+      1,
+      3
+    ],
+    "user_permissions": []
+  }
+},
+{
+  "model": "member.authuser",
+  "pk": 12,
+  "fields": {
+    "password": "pbkdf2_sha256$600000$GCQkAMispOGQcguk8CJexU$pKn3ZEC0B0D3u4YGso+Dh5CHJn2sH20JR35qRWWoOgg=",
+    "last_login": null,
+    "is_superuser": false,
+    "person": 15,
+    "has_temporary_password": true,
+    "agreed_terms": false,
+    "email": "onboarding@user.com",
+    "date_joined": "2026-05-08T02:50:48.261Z",
+    "is_active": true,
+    "is_staff": false,
+    "groups": [
+      4
     ],
     "user_permissions": []
   }

--- a/saskatoon/fixtures/member-onboarding.json
+++ b/saskatoon/fixtures/member-onboarding.json
@@ -1,0 +1,12 @@
+[
+{
+  "model": "member.onboarding",
+  "pk": 1,
+  "fields": {
+    "name": "First Pickleader Training",
+    "datetime": "2026-05-08T02:50:48.240Z",
+    "all_sent": false,
+    "log": "[May 07, 2026 @ 10:52 PM]\r\n\t> OK onboarding@user.com"
+  }
+}
+]

--- a/saskatoon/fixtures/member-person.json
+++ b/saskatoon/fixtures/member-person.json
@@ -29,7 +29,7 @@
     "language": "en",
     "first_name": "Pick",
     "family_name": "Leader",
-    "phone": null,
+    "phone": "(333) 333-3333",
     "street_number": null,
     "street": null,
     "complement": null,
@@ -42,7 +42,7 @@
     "longitude": null,
     "latitude": null,
     "comments": "",
-    "onboarding": null
+    "onboarding": 1
   }
 },
 {
@@ -204,6 +204,52 @@
     "latitude": null,
     "comments": "",
     "onboarding": null
+  }
+},
+{
+  "model": "member.person",
+  "pk": 14,
+  "fields": {
+    "language": "fr",
+    "first_name": "Inactive",
+    "family_name": "User",
+    "phone": null,
+    "street_number": null,
+    "street": null,
+    "complement": null,
+    "postal_code": null,
+    "neighborhood": 11,
+    "city": 1,
+    "state": 1,
+    "country": 1,
+    "newsletter_subscription": false,
+    "longitude": null,
+    "latitude": null,
+    "comments": "",
+    "onboarding": null
+  }
+},
+{
+  "model": "member.person",
+  "pk": 15,
+  "fields": {
+    "language": "fr",
+    "first_name": "Onboarding",
+    "family_name": "User",
+    "phone": "111-111-1111, press 1",
+    "street_number": null,
+    "street": null,
+    "complement": null,
+    "postal_code": null,
+    "neighborhood": null,
+    "city": 1,
+    "state": 1,
+    "country": 1,
+    "newsletter_subscription": false,
+    "longitude": null,
+    "latitude": null,
+    "comments": "",
+    "onboarding": 1
   }
 }
 ]

--- a/saskatoon/member/admin_filters.py
+++ b/saskatoon/member/admin_filters.py
@@ -40,8 +40,9 @@ class UserHasPasswordAdminFilter(SimpleListFilter):
         return [
             ('0', 'has no password'),
             ('1', 'has password'),
-            ('2', 'onboarding pickleader'),
-            ('3', 'active pickleader'),
+            ('2', 'has temporary password'),
+            ('3', 'onboarding pickleader'),
+            ('4', 'active pickleader'),
         ]
 
     def queryset(self, request, queryset):
@@ -55,12 +56,15 @@ class UserHasPasswordAdminFilter(SimpleListFilter):
             return queryset.exclude(password__exact='')
 
         if self.value() == '2':
+            return queryset.exclude(password__exact='').filter(has_temporary_password=True)
+
+        if self.value() == '3':
             group = Group.objects.get(name='volunteer')
             return queryset.exclude(password__exact='').filter(
                 groups__in=[group], is_active=True, has_temporary_password=True
             )
 
-        if self.value() == '3':
+        if self.value() == '4':
             group = Group.objects.get(name='pickleader')
             return queryset.exclude(password__exact='').filter(
                 groups__in=[group], is_active=True, has_temporary_password=False

--- a/saskatoon/sitebase/tests.py
+++ b/saskatoon/sitebase/tests.py
@@ -9,7 +9,7 @@ logger = getLogger('saskatoon')
 
 def get_test_owner_person() -> Optional[Person]:
     try:
-        return Person.objects.get(first_name='TEST', family_name='OWNER')
+        return Person.objects.get(first_name='Nice', family_name='Owner')
     except Person.DoesNotExist:
         logger.warning("Could not find test owner")
         return None
@@ -17,7 +17,6 @@ def get_test_owner_person() -> Optional[Person]:
 
 def get_test_property() -> Optional[Property]:
     test_owner = get_test_owner_person()
-    print(test_owner, test_owner is not None)
     if test_owner is not None:
         try:
             return Property.objects.get(owner=test_owner)

--- a/saskatoon/unittests/baselines/community_list.json
+++ b/saskatoon/unittests/baselines/community_list.json
@@ -1,17 +1,54 @@
 {
-    "count": 9,
-    "next": null,
+    "count": 11,
+    "next": "http://testserver/community/?format=json&page=2",
     "previous": null,
-    "pages_count": 1,
+    "pages_count": 2,
     "current_page_number": 1,
     "items_per_page": 10,
     "results": [
+        {
+            "id": 12,
+            "person": {
+                "actor_id": 15,
+                "roles": [
+                    "Volunteer Picker"
+                ],
+                "name": "Onboarding User",
+                "email": "onboarding@user.com",
+                "phone": "111-111-1111, press 1",
+                "neighborhood": null,
+                "comments": "",
+                "harvests": [],
+                "organizations_as_contact": [],
+                "properties": []
+            },
+            "roles": [
+                "Volunteer Picker"
+            ],
+            "role_codes": [
+                "volunteer"
+            ],
+            "date_joined": "2026-05-07",
+            "password": "pbkdf2_sha256$600000$GCQkAMispOGQcguk8CJexU$pKn3ZEC0B0D3u4YGso+Dh5CHJn2sH20JR35qRWWoOgg=",
+            "last_login": null,
+            "is_superuser": false,
+            "has_temporary_password": true,
+            "agreed_terms": false,
+            "email": "onboarding@user.com",
+            "is_active": true,
+            "is_staff": false,
+            "groups": [
+                4
+            ],
+            "user_permissions": []
+        },
         {
             "id": 10,
             "person": {
                 "actor_id": 13,
                 "roles": [
-                    "Property Owner"
+                    "Property Owner",
+                    "Volunteer Picker"
                 ],
                 "name": "Michelle Delepeche",
                 "email": "michelle@delpe.ch",
@@ -47,10 +84,12 @@
                 ]
             },
             "roles": [
-                "Property Owner"
+                "Property Owner",
+                "Volunteer Picker"
             ],
             "role_codes": [
-                "owner"
+                "owner",
+                "volunteer"
             ],
             "date_joined": "2026-01-25",
             "password": "",
@@ -62,7 +101,8 @@
             "is_active": true,
             "is_staff": false,
             "groups": [
-                2
+                2,
+                4
             ],
             "user_permissions": []
         },
@@ -181,8 +221,8 @@
             "roles": [],
             "role_codes": [],
             "date_joined": "2026-01-24",
-            "password": "pbkdf2_sha256$260000$5Q49AEg1qHuIf9Ijtk23YY$41k91lHX/m8fEVopi22ZFrixcUBTtYI56GpyjkKH79Q=",
-            "last_login": "2026-01-24T10:27:24.183000-05:00",
+            "password": "pbkdf2_sha256$600000$QYYe9epryqzrNGNFJ62V7x$1zpWIvEfIWW4KVFFfasVqSShjKMI6phq9jeDDErjygU=",
+            "last_login": "2026-05-08T07:55:14.028000-04:00",
             "is_superuser": true,
             "has_temporary_password": false,
             "agreed_terms": true,
@@ -236,6 +276,49 @@
             "is_staff": false,
             "groups": [
                 5
+            ],
+            "user_permissions": []
+        },
+        {
+            "id": 11,
+            "person": {
+                "actor_id": 14,
+                "roles": [
+                    "Core Member",
+                    "Pick Leader"
+                ],
+                "name": "Inactive User",
+                "email": "inactive@user.com",
+                "phone": null,
+                "neighborhood": {
+                    "id": 11,
+                    "name": "Mile End"
+                },
+                "comments": "",
+                "harvests": [],
+                "organizations_as_contact": [],
+                "properties": []
+            },
+            "roles": [
+                "Core Member",
+                "Pick Leader"
+            ],
+            "role_codes": [
+                "core",
+                "pickleader"
+            ],
+            "date_joined": "2022-05-07",
+            "password": "pbkdf2_sha256$600000$inQFnMH8U4kUqswGDKlGkq$ei3cFOYmKOx5IVXjWr0NXcCroqzcVrQVgVR8nM1mfV4=",
+            "last_login": "2022-05-13T07:55:14.028000-04:00",
+            "is_superuser": false,
+            "has_temporary_password": false,
+            "agreed_terms": false,
+            "email": "inactive@user.com",
+            "is_active": false,
+            "is_staff": true,
+            "groups": [
+                1,
+                3
             ],
             "user_permissions": []
         },
@@ -312,7 +395,7 @@
                 "owner"
             ],
             "date_joined": "2021-06-15",
-            "password": "pbkdf2_sha256$260000$x6u0VuwTbimW0Or07AA0Pz$Y3O+P8b9QPZSvDDgTS/+KE9gJX6o1C+4PC5Zv3n9Oqg=",
+            "password": "",
             "last_login": null,
             "is_superuser": false,
             "has_temporary_password": false,
@@ -490,74 +573,6 @@
             "is_staff": false,
             "groups": [
                 4
-            ],
-            "user_permissions": []
-        },
-        {
-            "id": 2,
-            "person": {
-                "actor_id": 3,
-                "roles": [
-                    "Pick Leader"
-                ],
-                "name": "Pick Leader",
-                "email": "pick@leader.com",
-                "phone": null,
-                "neighborhood": {
-                    "id": 34,
-                    "name": "Autre"
-                },
-                "comments": "",
-                "harvests": [
-                    {
-                        "id": 2,
-                        "pick_leader": "Pick Leader",
-                        "property": "Nice Owner at 123 av. Mont-Royal",
-                        "status": "ready",
-                        "status_display": "Ready",
-                        "start_date": "2026-07-24",
-                        "role": "pickleader"
-                    },
-                    {
-                        "id": 1,
-                        "pick_leader": "Pick Leader",
-                        "property": "Nice Owner at 123 av. Mont-Royal",
-                        "status": "succeeded",
-                        "status_display": "Succeeded",
-                        "start_date": "2026-01-19",
-                        "role": "pickleader"
-                    },
-                    {
-                        "id": 7,
-                        "pick_leader": "Core Member",
-                        "property": "Michelle Delepeche at 67 rue de l'Oseille",
-                        "status": "succeeded",
-                        "status_display": "Succeeded",
-                        "start_date": "2025-08-06",
-                        "role": "volunteer",
-                        "rfp_status": "accepted"
-                    }
-                ],
-                "organizations_as_contact": [],
-                "properties": []
-            },
-            "roles": [
-                "Pick Leader"
-            ],
-            "role_codes": [
-                "pickleader"
-            ],
-            "date_joined": "2021-05-26",
-            "password": "pbkdf2_sha256$260000$B4izrSL5cMDhpz76Ml8oAd$y+vALyJB3hKoOGYietAefzmZQMA0TSPrbGq4WLI7yvs=",
-            "last_login": "2021-06-15T17:26:05.253000-04:00",
-            "is_superuser": false,
-            "has_temporary_password": false,
-            "agreed_terms": false,
-            "email": "pick@leader.com",
-            "is_active": true,
-            "is_staff": true,
-            "groups": [
-                3
             ],
             "user_permissions": []
         }

--- a/saskatoon/unittests/baselines/harvest_list.json
+++ b/saskatoon/unittests/baselines/harvest_list.json
@@ -171,7 +171,7 @@
                 "neighborhood": "Plateau-Mont-Royal"
             },
             "volunteers": {
-                "pending": 0,
+                "pending": 1,
                 "accepted": 0,
                 "declined": 0,
                 "cancelled": 0,

--- a/saskatoon/unittests/baselines/property_detail.json
+++ b/saskatoon/unittests/baselines/property_detail.json
@@ -148,11 +148,12 @@
             "pick_leader": {
                 "actor_id": 3,
                 "roles": [
-                    "Pick Leader"
+                    "Pick Leader",
+                    "Volunteer Picker"
                 ],
                 "name": "Pick Leader",
                 "email": "pick@leader.com",
-                "phone": null,
+                "phone": "(333) 333-3333",
                 "neighborhood": {
                     "id": 34,
                     "name": "Autre"
@@ -335,11 +336,12 @@
             "pick_leader": {
                 "actor_id": 3,
                 "roles": [
-                    "Pick Leader"
+                    "Pick Leader",
+                    "Volunteer Picker"
                 ],
                 "name": "Pick Leader",
                 "email": "pick@leader.com",
-                "phone": null,
+                "phone": "(333) 333-3333",
                 "neighborhood": {
                     "id": 34,
                     "name": "Autre"

--- a/saskatoon/unittests/conftest.py
+++ b/saskatoon/unittests/conftest.py
@@ -11,6 +11,7 @@ FIXTURE_SEQUENCE = [
     'member-neighborhood',
     'member-state',
     'member-country',
+    'member-onboarding',
     'member-actor',
     'member-person',
     'member-organization',


### PR DESCRIPTION
Init Fixtures:
- add onboarding pickleader (volunteer with temporary password)
- add volunteer role to existing owner
- remove password from owner users
- add inactive user
- set better debug passwords

Additionally:
- add `has_temporary_password` admin filter
- fix test email user