### PR TITLE
fix: truncate RFP comment

### DIFF
--- a/saskatoon/sitebase/templates/app/detail_views/harvest/data_row.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/data_row.html
@@ -27,7 +27,7 @@
     <td style="text-align: center;">{{ r.number_of_pickers }}</td>
 
     <!-- Requester comment -->
-    <td>{{ r.comment }}</td>
+    <td title="{{r.comment}}">{{ r.comment|truncatechars:100 }}</td>
 
     <!-- Past experience -->
     <td style="text-align: center;">


### PR DESCRIPTION
Fix #705 

<img width="502" height="230" alt="screenshot_2026-05-17_21:57:54" src="https://github.com/user-attachments/assets/5773381f-21b6-46df-8249-763fbdc74a93" />


Note: hovering over the text displays the full comment