### PR TITLE
fix: Authorize button visibility + pending True in PublicPropertyForm

### DIFF
--- a/saskatoon/harvest/api.py
+++ b/saskatoon/harvest/api.py
@@ -150,7 +150,10 @@ class PropertyViewset(LoginRequiredMixin, viewsets.ModelViewSet[Property]):
     @action(methods=['post'], detail=True, permission_classes=[IsCoreOrAdmin])
     def send_authorization_email(self, request, pk=None):
         property = self.get_object()
-        recipient = property.owner.person
+        recipient = property.email_recipient
+        if recipient is None:
+            messages.error(request, _("No email address associated with property!"))
+            return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 
         if Email.objects.create(
             recipient=recipient,

--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -283,6 +283,7 @@ class PublicPropertyForm(forms.ModelForm[Property]):
     class Meta:
         model = Property
         fields = (
+            'pending',
             'pending_contact_first_name',
             'pending_contact_family_name',
             'pending_contact_email',
@@ -318,6 +319,7 @@ class PublicPropertyForm(forms.ModelForm[Property]):
         }
 
         widgets = {
+            'pending': forms.HiddenInput(),
             'trees': autocomplete.ModelSelect2Multiple('tree-autocomplete'),
             'avg_nb_required_pickers': forms.NumberInput(),
         }
@@ -435,6 +437,8 @@ class PublicPropertyForm(forms.ModelForm[Property]):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.initial['pending'] = True
         self.fields['avg_nb_required_pickers'].widget.attrs['min'] = 1
         self.fields['number_of_trees'].widget.attrs['min'] = 1
         self.fields['fruits_height'].widget.attrs['min'] = 1
@@ -444,8 +448,8 @@ class PublicPropertyForm(forms.ModelForm[Property]):
     def clean(self):
         cleaned_data = super().clean()
         logger.info("Pending property form submitted by %s", cleaned_data['pending_contact_email'])
-        postal_code = cleaned_data['postal_code'].replace(" ", "")
 
+        postal_code = cleaned_data['postal_code'].replace(" ", "")
         try:
             cleaned_data['postal_code'] = parse_postal_code(postal_code)
         except ValueError as invalid_postal_code:

--- a/saskatoon/harvest/locale/fr/LC_MESSAGES/django.po
+++ b/saskatoon/harvest/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-18 20:30-0400\n"
+"POT-Creation-Date: 2026-05-19 17:46-0400\n"
 "PO-Revision-Date: 2025-06-13 11:05-0518\n"
 "Last-Translator: Anonymous User\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,7 +35,7 @@ msgstr "Organisme"
 msgid "New Harvest"
 msgstr "Nouvelle Cueillette"
 
-#: harvest/api.py:134 harvest/api.py:209
+#: harvest/api.py:134 harvest/api.py:212
 msgid "New Property"
 msgstr "Nouvelle Propriété"
 
@@ -47,21 +47,25 @@ msgstr "Création de propriété réussie!"
 msgid "Something went wrong"
 msgstr "Une erreur est survenue"
 
-#: harvest/api.py:161
+#: harvest/api.py:155
+msgid "No email address associated with property!"
+msgstr "Aucun courriel n'est associé à la propriété!"
+
+#: harvest/api.py:164
 #, python-brace-format
 msgid "Authorization email successfully sent to {email}!"
 msgstr "Courriel d'autorisation envoyé avec succès à {email}!"
 
-#: harvest/api.py:168
+#: harvest/api.py:171
 #, python-brace-format
 msgid "Could not send authorization email to {email}."
 msgstr "L'envoi du courriel d'autorisation à {email} a échoué."
 
-#: harvest/api.py:245
+#: harvest/api.py:248
 msgid "New Equipment"
 msgstr "Nouvel Équipement"
 
-#: harvest/api.py:294
+#: harvest/api.py:297
 msgid "No harvests found for the selected season(s)"
 msgstr "Aucune récolte trouvée pour la saison sélectionnée"
 
@@ -109,8 +113,8 @@ msgstr "Arrondissement"
 msgid "Reserved equipment"
 msgstr "A réservé de l'équipement"
 
-#: harvest/filters.py:82 harvest/filters.py:187 harvest/forms.py:510
-#: harvest/forms.py:689
+#: harvest/filters.py:82 harvest/filters.py:187 harvest/forms.py:514
+#: harvest/forms.py:693
 msgid "Equipment Point"
 msgstr "Point d'équipement"
 
@@ -154,11 +158,11 @@ msgstr "Combien de personnes êtes-vous?"
 msgid "First name"
 msgstr "Prénom"
 
-#: harvest/forms.py:54 harvest/forms.py:317
+#: harvest/forms.py:54 harvest/forms.py:318
 msgid "Last name"
 msgstr "Nom"
 
-#: harvest/forms.py:55 harvest/forms.py:246 harvest/forms.py:331
+#: harvest/forms.py:55 harvest/forms.py:246 harvest/forms.py:333
 msgid "Email"
 msgstr "Courriel"
 
@@ -166,7 +170,7 @@ msgstr "Courriel"
 msgid "Enter a valid email address, please."
 msgstr "Merci d'inscrire une adresse courriel valide."
 
-#: harvest/forms.py:56 harvest/forms.py:316
+#: harvest/forms.py:56 harvest/forms.py:317
 msgid "Phone number"
 msgstr "Numéro de téléphone"
 
@@ -219,7 +223,7 @@ msgstr ""
 msgid "Register new owner"
 msgstr "Inscrire un nouveau propriétaire"
 
-#: harvest/forms.py:238 harvest/forms.py:326
+#: harvest/forms.py:238 harvest/forms.py:328
 msgid "First Name"
 msgstr "Prénom"
 
@@ -244,33 +248,33 @@ msgstr ""
 "créer un.e nouveau.elle propriétaire en fournissant ses informations "
 "personnelles"
 
-#: harvest/forms.py:336
+#: harvest/forms.py:338
 msgid ""
 "Volunteers have permission to go on the neighbours property to access fruits"
 msgstr ""
 "Les cueilleurs (cueilleuses) ont la permission de passer sur le terrain "
 "voisin afin d'accéder aux fruits"
 
-#: harvest/forms.py:341
+#: harvest/forms.py:343
 msgid "I have a compost bin where you can leave rotten fruit"
 msgstr ""
 "J'ai un bac de compostage dans lequel vous pouvez mettre les fruits abîmés "
 "ou pourris"
 
-#: harvest/forms.py:346
+#: harvest/forms.py:348
 msgid "I have a ladder that can be used during the harvest"
 msgstr "J'ai une échelle qui pourra être utilisée pendant la cueillette"
 
-#: harvest/forms.py:351
+#: harvest/forms.py:353
 msgid "I would lend my ladder for another harvest nearby"
 msgstr "Je peux prêter mon échelle lors d'une cueillette à proximité"
 
-#: harvest/forms.py:356
+#: harvest/forms.py:358
 msgid "My tree(s)/vine(s) produce fruit every year"
 msgstr ""
 "Mon arbre (mes arbres) ou vigne(s) produise(nt) des fruits annuellement"
 
-#: harvest/forms.py:358
+#: harvest/forms.py:360
 msgid ""
 "if not, please include info about frequency in additional comments at the "
 "bottom"
@@ -278,43 +282,43 @@ msgstr ""
 "(sinon, merci de préciser leur fréquence de production dans les Commentaires "
 "ci-dessous)"
 
-#: harvest/forms.py:364
+#: harvest/forms.py:366
 msgid "Have you already registered your property in the past?"
 msgstr "Avez vous déjà inscrit votre propriété par le passé"
 
-#: harvest/forms.py:365 harvest/forms.py:372
+#: harvest/forms.py:367 harvest/forms.py:374
 msgid "Yes"
 msgstr "Oui"
 
-#: harvest/forms.py:365
+#: harvest/forms.py:367
 msgid "No"
 msgstr "Non"
 
-#: harvest/forms.py:370
+#: harvest/forms.py:372
 msgid ""
 "Do you give us permission to harvest your tree(s) and/or vine(s) this season?"
 msgstr ""
 "Vous donnez-nous la permission de récolter votre arbre (vos arbres) ou "
 "vigne(s) cette saison ?"
 
-#: harvest/forms.py:373
+#: harvest/forms.py:375
 msgid "Not this year, but maybe in future seasons"
 msgstr "Pas cette année, peut-être dans le futur"
 
-#: harvest/forms.py:384
+#: harvest/forms.py:386
 msgid "Location of tree(s) or vine(s)"
 msgstr "Emplacement de l'arbre (des arbres) ou vigne(s)"
 
-#: harvest/forms.py:385
+#: harvest/forms.py:387
 msgid "Location on the property (e.g. Front yard, back yard, etc.)"
 msgstr ""
 "Emplacement sur la propriété (par exemple: Jardin avant, cours arrière, etc.)"
 
-#: harvest/forms.py:390
+#: harvest/forms.py:392
 msgid "Access to tree(s) or vine(s)"
 msgstr "Accès à l'arbre (aux arbres) ou vigne(s)"
 
-#: harvest/forms.py:392
+#: harvest/forms.py:394
 msgid ""
 "Any info on how to access the tree(s) or vine(s)(e.g. locked gate in back, "
 "publicly accessible from sidewalk, etc.)"
@@ -323,37 +327,37 @@ msgstr ""
 "(par exemple: porte verrouillée à l'arrière, accès libre depuis la rue, "
 "etc...)"
 
-#: harvest/forms.py:399 harvest/models.py:818
+#: harvest/forms.py:401 harvest/models.py:818
 msgid "Number of pickers"
 msgstr "Nombre de cueilleurs (cueilleuses)"
 
-#: harvest/forms.py:400
+#: harvest/forms.py:402
 msgid "Approximate number of pickers needed for a two-hour harvesting period."
 msgstr ""
 "Nombre approximatif de cueilleurs (cueilleuses) requis pour une cueillette "
 "de deux heures"
 
-#: harvest/forms.py:404 harvest/models.py:286
+#: harvest/forms.py:406 harvest/models.py:286
 msgid "Height of lowest fruits (meters)"
 msgstr "Hauteur des fruits les plus bas (en mètres)"
 
-#: harvest/forms.py:406
+#: harvest/forms.py:408
 msgid "Address number"
 msgstr "Adresse civique"
 
-#: harvest/forms.py:409 harvest/models.py:273
+#: harvest/forms.py:411 harvest/models.py:273
 msgid "Total number of trees/vines on this property"
 msgstr "Nombre total d'arbre(s) ou de vigne(s) sur la propriété"
 
-#: harvest/forms.py:412
+#: harvest/forms.py:414
 msgid "Street name"
 msgstr "Nom de la rue"
 
-#: harvest/forms.py:414
+#: harvest/forms.py:416
 msgid "Apartment # (if applicable)"
 msgstr "Numéro d'appartement (si applicable)"
 
-#: harvest/forms.py:420
+#: harvest/forms.py:422
 msgid ""
 "I would like to receive emails from Les Fruits Defendus such as newsletters "
 "and updates"
@@ -361,7 +365,7 @@ msgstr ""
 "Je souhaite recevoir les courriels de la part des Fruits Défendus (nouvelles "
 "et bulletin d'information) Fruits Défendus"
 
-#: harvest/forms.py:428
+#: harvest/forms.py:430
 msgid ""
 "Any additional information that we should be aware of (e.g. details about "
 "how often tree produces fruit, fruit description if not already in the list, "
@@ -371,28 +375,28 @@ msgstr ""
 "fréquence de production de fruits, description des fruits si ceux-ci ne sont "
 "pas déjà dans la liste, etc..."
 
-#: harvest/forms.py:494
+#: harvest/forms.py:498
 msgid "Start date/time"
 msgstr "Date de début"
 
-#: harvest/forms.py:496
+#: harvest/forms.py:500
 msgid "End date/time"
 msgstr "Date/heure de fin"
 
-#: harvest/forms.py:499
+#: harvest/forms.py:503
 msgid "Publication date (optional)"
 msgstr "Date de publication"
 
-#: harvest/forms.py:500
+#: harvest/forms.py:504
 msgid "Leave this field empty to publish harvest as soon as possible"
 msgstr "Laissez ce champ vide pour publier la récolte le plus tôt possible"
 
-#: harvest/forms.py:511 harvest/forms.py:596
+#: harvest/forms.py:515 harvest/forms.py:600
 msgid "Harvest must be confirmed before an equipment point can be booked"
 msgstr ""
 "La récolte doit être confirmée avant de pouvoir réserver un point d'équipment"
 
-#: harvest/forms.py:541
+#: harvest/forms.py:545
 msgid ""
 "Harvests cannot be scheduled over multiple days: start and end dates must "
 "match."
@@ -400,30 +404,30 @@ msgstr ""
 "Une récolte ne peut pas être schedulée sur plusieurs jours: les dates de "
 "début et de fin doivent être les mêmes."
 
-#: harvest/forms.py:547
+#: harvest/forms.py:551
 msgid "End time must be after start time"
 msgstr "La date de fin doit être après la date de début"
 
-#: harvest/forms.py:561
+#: harvest/forms.py:565
 msgid "Selected tree(s) <{}> not registered on the selected property."
 msgstr ""
 "L'arbre sélectionné <{}> n'est pas enregistré sur la propriété sélectionnée."
 
-#: harvest/forms.py:579
+#: harvest/forms.py:583
 msgid "Please fill in the public announcement to be published on the calendar."
 msgstr "Remplissez l'annonce qui sera visible publiquement sur le calendrier."
 
-#: harvest/forms.py:610
+#: harvest/forms.py:614
 msgid "The {} equipment point is no longer available."
 msgstr "Le point d'équipement {} n'est plus disponible"
 
-#: harvest/forms.py:631
+#: harvest/forms.py:635
 msgid "This harvest cannot be left orphan, please resolve requests first."
 msgstr ""
 "Cette récolte ne peut pas être laissée orpheline, merci de résoudre les "
 "demandes de participation en cours."
 
-#: harvest/forms.py:640
+#: harvest/forms.py:644
 msgid "You must choose a pick leader or change harvest status"
 msgstr ""
 "Vous devez choisir un.e chef.fe de ceuillette ou changer le statut de la "

--- a/saskatoon/harvest/serializers.py
+++ b/saskatoon/harvest/serializers.py
@@ -125,13 +125,14 @@ class PropertySerializer(serializers.ModelSerializer[Property]):
         return similar_properties(obj)
 
     def get_auth_email_date(self, obj):
-        if obj.owner is None or obj.owner.person is None:
+        recipient = obj.email_recipient
+        if recipient is None:
             return None
 
         sent = Email.objects.filter(
             type=EmailType.SEASON_AUTHORIZATION,
             date_sent__year=tz.now().date().year,
-            recipient=obj.owner.person,
+            recipient=recipient,
             sent=True,
         )
         if not sent.exists():

--- a/saskatoon/sitebase/templates/app/detail_views/property/breadcomb.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/breadcomb.html
@@ -43,7 +43,7 @@
                         <div class="col-lg-3 col-md-3 col-sm-3 col-xs-3 text-right">
                             <div class="form-group" style="margin-top: 1em;">
                                 {% if perms.harvest.change_property %}
-                                    {% if not pending and not authorized is None %}
+                                    {% if not pending and authorized is None %}
                                         <button title="Authorize"
                                                 class="btn btn-success notika-btn-success"
                                                 onclick="authorizeProperty({{ id }})">


### PR DESCRIPTION
- Authorize button was not showing when property had `authorized=None`
- Send Email assumed recipient was `property.owner.person` 
- Set `pending: True` before calling clean() on PublicPropertyForm