### PR TITLE
fixed issue where text is illegible on hover and restored dropdown co…

### DIFF
--- a/saskatoon/sitebase/static/css/harvest-details.css
+++ b/saskatoon/sitebase/static/css/harvest-details.css
@@ -10,6 +10,58 @@
 
     .dropdown {
         width: fit-content;
+
+        .btn.dropdown-toggle.btn-default {
+            &.saskatoon-warning {
+                background-color: var(--saskatoon-warning);
+            }
+
+            &.saskatoon-info {
+                background-color: var(--saskatoon-info);
+            }
+
+            &.saskatoon-success {
+                background-color: var(--saskatoon-success);
+            }
+
+            &.saskatoon-danger {
+                background-color: var(--saskatoon-danger);
+            }
+
+            &:hover,
+            &:focus,
+            &:active {
+                filter: brightness(90%);
+                color: #ffffff;
+                border-color: transparent;
+                box-shadow: none;
+            }
+        }
+
+        .status-dropdown-title {
+            font-size: 1.2em;
+            color: #ffffff;
+            margin: 0;
+        }
+
+        .dropdown-menu.harvest-status-menu > li > a.status-dropdown-item {
+            display: flex;
+            padding-left: 8px;
+            padding-right: 12px;
+            font-weight: bold;
+        }
+
+        .harvest-status-menu .status-icon-wrapper {
+            display: inline-block;
+            width: 20px;
+            margin-right: 8px;
+            flex-shrink: 0;
+        }
+
+        p {
+            margin: 0;
+            padding: 0;
+        }
     }
 
     .equipment-point {
@@ -90,7 +142,6 @@
         margin-bottom: var(--saskatoon-gap);
     }
 
-
     .harvest-info > section,
     .property-and-announcements > section,
     .distribution-and-comments > section,
@@ -155,9 +206,4 @@
             margin: 0;
         }
     }
-}
-
-.dropdown p {
-    margin: 0;
-    padding: 0;
 }

--- a/saskatoon/sitebase/static/css/harvest-details.css
+++ b/saskatoon/sitebase/static/css/harvest-details.css
@@ -2,10 +2,14 @@
     --saskatoon-gap: 15px;
 }
 
-.harvest-details {
 
-    .tooltip.right {
-        min-width: 15em;
+.tooltip.right {
+    min-width: 15em;
+}
+
+.harvest-details {
+    .dropdown.open ~ .tooltip.top {
+        opacity: 0;
     }
 
     .dropdown {
@@ -44,11 +48,25 @@
             margin: 0;
         }
 
-        .dropdown-menu.harvest-status-menu > li > a.status-dropdown-item {
-            display: flex;
-            padding-left: 8px;
-            padding-right: 12px;
-            font-weight: bold;
+        .dropdown-menu.harvest-status-menu {
+            padding: 0;
+            border: 1px solid #ccc;
+
+            > li {
+                margin: 0;
+
+                > a.status-dropdown-item {
+                    display: flex;
+                    width: 100%;
+                    padding: 15px 15px;
+                    font-weight: bold;
+
+                    &:hover,
+                    &:focus {
+                        background-color: #e7e0f9aa;
+                    }
+                }
+            }
         }
 
         .harvest-status-menu .status-icon-wrapper {

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/status_choices.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/status_choices.html
@@ -14,19 +14,13 @@
         </p>
     </button>
     <ul
-        class="dropdown-menu"
+        class="dropdown-menu harvest-status-menu"
         role="menu"
         aria-labelledby="menu1"
     >
         {% for choice in status_choices %}
             <li role="presentation" {{ choice.0 | harvest_status_attributes:"right" | safe }}>
-                <a
-                href="{% url 'harvest-status-change' id %}?status={{ choice.0 }}"
-                role="menuitem"
-                tabindex="-1"
-                >
-                {{ choice.1 }}
-            </a>
+                <a href="{% url 'harvest-status-change' id %}?status={{ choice.0 }}" role="menuitem" tabindex="-1" class="status-dropdown-item"><span class="status-icon-wrapper {{ choice.0 | color }}">{{ choice.0 | harvest_icon | safe }}</span><span>{{ choice.1 }}</span></a>
             </li>
             {% if not forloop.last %}
                 <li role="presentation" class="divider"></li>


### PR DESCRIPTION
Fixes #702
----------
## Type of change:
- [ ] Bug fix:fixed issue where text and background both turn grey when you hover on the harvest status button.
----------
## What's Changed:
- hovering on the status button changes text colour to grey but keeps the button colour
- while selecting a new status the dropdown options have colour-coded icons
- fixed background color on the dropdown hover (fills row, removed extra margins/padding, used correct color)
- top tooltip disappears when dropdown is open

--------
## Screenshots:
1. Button on hover 
<img width="369" height="209" alt="onHover" src="https://github.com/user-attachments/assets/4dc67320-b742-49a8-b1bc-3bc94b7d7936" />

2. dropdown item on hover
<img width="400" height="422" alt="hoverListItem" src="https://github.com/user-attachments/assets/9554e87c-e9c6-4511-98c6-b21ddb3ea1ea" />

--------
## Affected URLs:
127.0.0.1:8000/harvest/
