### PR TITLE
Fix/status badge contrast 753

### DIFF
--- a/saskatoon/sitebase/static/css/harvest-details.css
+++ b/saskatoon/sitebase/static/css/harvest-details.css
@@ -104,6 +104,28 @@
         }
     }
 
+    .harvest-info {
+        .badge {
+            &.saskatoon-warning {
+                background-color: var(--saskatoon-warning);
+            }
+
+            &.saskatoon-info {
+                background-color: var(--saskatoon-info);
+            }
+
+            &.saskatoon-success {
+                background-color: var(--saskatoon-success);
+            }
+
+            &.saskatoon-danger {
+                background-color: var(--saskatoon-danger);
+            }
+
+            color: #ffffff;
+        }
+    }
+
     .harvest-info,
     .property-and-announcements,
     .distribution-and-comments {

--- a/saskatoon/sitebase/static/css/harvest-details.css
+++ b/saskatoon/sitebase/static/css/harvest-details.css
@@ -10,6 +10,58 @@
 
     .dropdown {
         width: fit-content;
+
+        .btn.dropdown-toggle.btn-default {
+            &.saskatoon-warning {
+                background-color: var(--saskatoon-warning);
+            }
+
+            &.saskatoon-info {
+                background-color: var(--saskatoon-info);
+            }
+
+            &.saskatoon-success {
+                background-color: var(--saskatoon-success);
+            }
+
+            &.saskatoon-danger {
+                background-color: var(--saskatoon-danger);
+            }
+
+            &:hover,
+            &:focus,
+            &:active {
+                filter: brightness(90%);
+                color: #ffffff;
+                border-color: transparent;
+                box-shadow: none;
+            }
+        }
+
+        .status-dropdown-title {
+            font-size: 1.2em;
+            color: #ffffff;
+            margin: 0;
+        }
+
+        .dropdown-menu.harvest-status-menu > li > a.status-dropdown-item {
+            display: flex;
+            padding-left: 8px;
+            padding-right: 12px;
+            font-weight: bold;
+        }
+
+        .harvest-status-menu .status-icon-wrapper {
+            display: inline-block;
+            width: 20px;
+            margin-right: 8px;
+            flex-shrink: 0;
+        }
+
+        p {
+            margin: 0;
+            padding: 0;
+        }
     }
 
     .equipment-point {
@@ -90,7 +142,6 @@
         margin-bottom: var(--saskatoon-gap);
     }
 
-
     .harvest-info > section,
     .property-and-announcements > section,
     .distribution-and-comments > section,
@@ -155,9 +206,4 @@
             margin: 0;
         }
     }
-}
-
-.dropdown p {
-    margin: 0;
-    padding: 0;
 }

--- a/saskatoon/sitebase/static/css/harvest-details.css
+++ b/saskatoon/sitebase/static/css/harvest-details.css
@@ -14,6 +14,7 @@
 
     .dropdown {
         width: fit-content;
+        padding-bottom: 1em;
 
         .btn.dropdown-toggle.btn-default {
             &.saskatoon-warning {
@@ -180,6 +181,20 @@
         }
 
         margin-bottom: var(--saskatoon-gap);
+    }
+
+    .harvest-info > section {
+        h2.badge {
+            margin-top: -8px;
+        }
+
+        .dropdown {
+            margin-top: -4px;
+        }
+
+        .btn {
+            margin-top: -4px;
+        }
     }
 
     .harvest-info > section,

--- a/saskatoon/sitebase/static/css/harvest-details.css
+++ b/saskatoon/sitebase/static/css/harvest-details.css
@@ -2,10 +2,14 @@
     --saskatoon-gap: 15px;
 }
 
-.harvest-details {
 
-    .tooltip.right {
-        min-width: 15em;
+.tooltip.right {
+    min-width: 15em;
+}
+
+.harvest-details {
+    .dropdown.open ~ .tooltip.top {
+        opacity: 0;
     }
 
     .dropdown {
@@ -44,11 +48,25 @@
             margin: 0;
         }
 
-        .dropdown-menu.harvest-status-menu > li > a.status-dropdown-item {
-            display: flex;
-            padding-left: 8px;
-            padding-right: 12px;
-            font-weight: bold;
+        .dropdown-menu.harvest-status-menu {
+            padding: 0;
+            border: 1px solid #ccc;
+
+            > li {
+                margin: 0;
+
+                > a.status-dropdown-item {
+                    display: flex;
+                    width: 100%;
+                    padding: 15px 15px;
+                    font-weight: bold;
+
+                    &:hover,
+                    &:focus {
+                        background-color: #e7e0f9aa;
+                    }
+                }
+            }
         }
 
         .harvest-status-menu .status-icon-wrapper {

--- a/saskatoon/sitebase/templates/app/detail_views/harvest/status_choices.html
+++ b/saskatoon/sitebase/templates/app/detail_views/harvest/status_choices.html
@@ -14,19 +14,13 @@
         </p>
     </button>
     <ul
-        class="dropdown-menu"
+        class="dropdown-menu harvest-status-menu"
         role="menu"
         aria-labelledby="menu1"
     >
         {% for choice in status_choices %}
             <li role="presentation" {{ choice.0 | harvest_status_attributes:"right" | safe }}>
-                <a
-                href="{% url 'harvest-status-change' id %}?status={{ choice.0 }}"
-                role="menuitem"
-                tabindex="-1"
-                >
-                {{ choice.1 }}
-            </a>
+                <a href="{% url 'harvest-status-change' id %}?status={{ choice.0 }}" role="menuitem" tabindex="-1" class="status-dropdown-item"><span class="status-icon-wrapper {{ choice.0 | color }}">{{ choice.0 | harvest_icon | safe }}</span><span>{{ choice.1 }}</span></a>
             </li>
             {% if not forloop.last %}
                 <li role="presentation" class="divider"></li>


### PR DESCRIPTION
Fixes #753
----------
## Type of change:
- [ ] Bug fix: black text on a blue button was hard to read. Made it white text which is consistent with the dropdown button for the harvest leader.
----------
## What's Changed:
- forced white text on buttons so bootstrap doesn't revert to black text on a dark button.
- aligned button and badge heights and section heights
- aligned button/badge text with rest of the horizontal text on the screen

--------
## Screenshots:
1. 
<img width="495" height="489" alt="staticButton" src="https://github.com/user-attachments/assets/af47127c-e246-4364-9fa0-b45accdc015d" />

2. aligned elements 
<img width="896" height="308" alt="alignment" src="https://github.com/user-attachments/assets/80244caf-e3dc-4bfe-b8b8-e54dc105bdaa" />

--------
## Affected URLs:
127.0.0.1:8000/harvest/