### PR TITLE
fix: set a more uniform spacing between the menu and the page elements

### DIFF
--- a/saskatoon/sitebase/static/css/responsive.css
+++ b/saskatoon/sitebase/static/css/responsive.css
@@ -6,7 +6,6 @@
 
     .nav.navbar-nav.notika-top-nav li {
         margin: 0px 5px;
-        ;
     }
 
     .logo-area {

--- a/saskatoon/sitebase/static/css/responsive.css
+++ b/saskatoon/sitebase/static/css/responsive.css
@@ -6,6 +6,7 @@
 
     .nav.navbar-nav.notika-top-nav li {
         margin: 0px 5px;
+        ;
     }
 
     .logo-area {
@@ -34,7 +35,7 @@
 /* xs & sm */
 @media (max-width: 991px) {
     .breadcomb-list {
-        padding: 0;
+        padding: 15px;
 
         > *:first-child {
             margin-bottom: 1em;
@@ -71,6 +72,7 @@
     .mobile-menu-area {
         background: #440bd4;
         display: block;
+        margin-bottom: 30px;
     }
 
     .header-top-menu {
@@ -124,6 +126,7 @@
 
     ul.notika-menu-wrap li a {
         padding: 5px;
+        margin-bottom: 10px;
     }
 
     ul.notika-main-menu-dropdown li > a {
@@ -444,7 +447,7 @@
     }
 
     .breadcomb-area {
-        margin-top: 40px;
+        margin: 0px;
     }
 
     .box-layout .header-top-area {


### PR DESCRIPTION
Fixes #754
----------
## Type of change:
- [ ] Bug fix 

----------
## What's Changed:
- added spacing so top menu has similar spacing at different screen sizes

--------
## Screenshots:
1. mobile and small screen side-by-side
<img width="1310" height="364" alt="Screenshot 2026-09-01 at 11 05 46 AM" src="https://github.com/user-attachments/assets/b4f00075-0519-4a0f-923a-7e296f9a3546" />

2. medium and full desktop side-by-side
<img width="1686" height="230" alt="Screenshot 2026-09-01 at 11 09 47 AM" src="https://github.com/user-attachments/assets/6ab94c69-aa96-4ec8-a2e7-5151054c13d8" />

--------
## Affected URLs:
127.0.0.1:8000/harvest/<int>, 127.0.0.1:8000/organization/<int>, 127.0.0.1:8000/property/<int>, etc,
 I believe it is all pages with the header