### PR TITLE
fix: harvest column overflow fixed issue#706

### DIFF
--- a/saskatoon/sitebase/static/css/list-view-tabs.css
+++ b/saskatoon/sitebase/static/css/list-view-tabs.css
@@ -54,3 +54,14 @@ tab-list {
         }
     }
 }
+
+.table-responsive .table td:nth-child(3) {
+    min-width: 100px;
+    white-space: nowrap;
+}
+
+.table-responsive .table td:nth-child(9),
+.table-responsive .table th:nth-child(9) {
+    min-width: 80px;
+    white-space: nowrap;
+}


### PR DESCRIPTION
Fixes #706
----------
## Type of change:
- [ ] Bug fix: french text was overriding its column and a final column had misaligned icons that could cause confusion

----------
## What's Changed:
- added minimum length to status column
- changed column length on 'volunteers' column so that its content stays aligned at all screen sizes

--------
## Screenshots:
1. status doesn't spillover to property
<img width="334" height="581" alt="finalSpacing" src="https://github.com/user-attachments/assets/c24dac1c-7dc1-4c1a-8d28-97482215918a" />


2. misaligned column issue
<img width="348" height="589" alt="unaligned" src="https://github.com/user-attachments/assets/4037de52-8ccc-46a9-8577-b97c62061b61" />


3. corrected alignment
<img width="352" height="590" alt="aligned" src="https://github.com/user-attachments/assets/7324a250-65ea-44b6-896a-56d1cf81a5b5" />

--------
## Affected URLs:
127.0.0.1:8000/harvest/