### PR TITLE
fix: add autocompletes to property and community, fixed dropdown styl…

### DIFF
--- a/saskatoon/harvest/filters.py
+++ b/saskatoon/harvest/filters.py
@@ -147,10 +147,15 @@ class PropertyFilter(filters.FilterSet):
         label=_("Borough"),
         help_text="",
         required=False,
+        widget=autocomplete.ModelSelect2('neighborhood-autocomplete'),
     )
 
     trees = filters.ModelChoiceFilter(
-        queryset=TreeType.objects.all(), label=_("Tree"), help_text="", required=False
+        queryset=TreeType.objects.all(),
+        label=_("Tree"),
+        help_text="",
+        required=False,
+        widget=autocomplete.ModelSelect2('tree-autocomplete'),
     )
 
     season = filters.ChoiceFilter(

--- a/saskatoon/member/autocomplete.py
+++ b/saskatoon/member/autocomplete.py
@@ -137,8 +137,6 @@ class EquipmentPointAutocomplete(Autocomplete):
 
         if start_str == "" and end_str == "":
             qs = Organization.objects.filter(is_equipment_point=True)
-        elif start_str == "" or end_str == "":
-            return none
         else:
             start = parse_naive_datetime(start_str)
             end = parse_naive_datetime(end_str)

--- a/saskatoon/member/filters.py
+++ b/saskatoon/member/filters.py
@@ -32,6 +32,7 @@ class CommunityFilter(filters.FilterSet):
         field_name='person__neighborhood',
         queryset=Neighborhood.objects.all(),
         label=_("Borough"),
+        widget=autocomplete.ModelSelect2('neighborhood-autocomplete'),
     )
 
     language = filters.ChoiceFilter(

--- a/saskatoon/sitebase/static/js/filter-form.js
+++ b/saskatoon/sitebase/static/js/filter-form.js
@@ -3,11 +3,20 @@ $(document).ready(function () {
         $('.collapse').collapse('show');
     }
 
-    $('#filter-panel').resize(function(){
-        const width = $(this).width()
-        const paddingRight = 24; // px
-        $('.select2-selection').each(function() {
-            $(this).width(width-paddingRight);
+    const filterPanel = document.getElementById('filter-panel');
+    
+    if (filterPanel) {
+        const observer = new ResizeObserver(entries => {
+            for (let entry of entries) {
+                const width = entry.contentRect.width;
+                const paddingRight = 24; // px
+                
+                $('.select2-selection, .select2-container').each(function() {
+                    $(this).width(width - paddingRight);
+                });
+            }
         });
-    });
+        
+        observer.observe(filterPanel);
+    }
 });


### PR DESCRIPTION
Fixes #N/A
----------
## Type of change:
- [ ] Bug fix: autocomplete boxes now available everywhere possible

----------
## What's Changed:
- borough autocomplete added to property and community pages
- tree autocomplete added to property page
- removed extraneous elseif statement from filter
- updated filter-form.js so that autocomplete boxes are resized properly and no longer load in outside the filter element
--------
## Screenshots:
1. boroughs and trees on property page
<img width="858" height="702" alt="autocompleteProperty" src="https://github.com/user-attachments/assets/585436f8-fd7e-4892-bdad-13c1e1e6441b" />

2. broken styling that shouldn't happen anymore
<img width="812" height="420" alt="badStyle" src="https://github.com/user-attachments/assets/680fe4ec-70b5-4cbd-9a82-3ea9dd8965f8" />

--------
## Affected URLs:
127.0.0.1:8000/property/
127.0.0.1:8000/community/