### PR TITLE
fix:inline styling to allow word-break

### DIFF
--- a/saskatoon/sitebase/templates/app/detail_views/property/about.html
+++ b/saskatoon/sitebase/templates/app/detail_views/property/about.html
@@ -35,7 +35,7 @@
 
             {% if additional_info %}
                 <h2>{% translate 'Additional information' %}</h2>
-                <p>{{ additional_info }}</p>
+                <p style="word-break: break-word;">{{ additional_info }}</p>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
Fixes #714
----------
## Type of change:
- [ ] Bug fix

----------
## What's Changed:
- used inline styling to allow word-break on long text in the property's 'additional information' section. 
There was no obvious direct css file associated and now that there are property comments available it seems 
unnecessary to over-complicate the fix

--------
## Screenshots:
1. 
<img width="379" height="434" alt="Screenshot 2026-09-09 at 2 39 16 PM" src="https://github.com/user-attachments/assets/087b6d2c-8dc7-44ae-85c3-f5ad514d12ac" />

--------
## Affected URLs:
127.0.0.1:8000/property/<int>