### PR TITLE
fix: tree types no longer spill out of box

### DIFF
--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -323,6 +323,7 @@ class PublicPropertyForm(forms.ModelForm[Property]):
         widgets = {
             'pending': forms.HiddenInput(),
             'trees': autocomplete.ModelSelect2Multiple('tree-autocomplete'),
+            'neighborhood': autocomplete.ModelSelect2('neighborhood-autocomplete'),
             'avg_nb_required_pickers': forms.NumberInput(),
         }
 

--- a/saskatoon/sitebase/static/css/vendor/dal/autocomplete_light.css
+++ b/saskatoon/sitebase/static/css/vendor/dal/autocomplete_light.css
@@ -9,3 +9,15 @@
     font-size: 1.1em;
     padding-left: 0px !important;
 }
+
+.select2-container--default .select2-selection--multiple,
+.form-group .select2-container {
+    width: 100%;
+    height: auto;
+}
+
+.select2-container--default .select2-selection--multiple .select2-selection__rendered {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}


### PR DESCRIPTION
Fixes #713
----------
## Type of change:
- [ ] Bug fix

## What's Changed:
- added styling so that adding tree types to a property no longer has the types floating all over the page. the box now expands to accomadate them
- added borough autocomplete to the new property form for ease of use
--------
## Screenshots:
1. public create property form on mobile
<img width="350" height="669" alt="publicCreateMobile" src="https://github.com/user-attachments/assets/c8f488b3-9b09-460e-9753-801045e3a701" />

2. edit property on medium screen
<img width="698" height="498" alt="propertyEditMedium" src="https://github.com/user-attachments/assets/569955d8-fd3c-4b42-ba2f-974863bcb86a" />

--------
## Affected URLs:
127.0.0.1:8000/property/create/
127.0.0.1:8000property/update/<int>/
127.0.0.1:8000/property/create_public/