### PR TITLE
fix: added break-word to contact email #575

### DIFF
--- a/saskatoon/sitebase/templates/app/detail_views/organization/contact.html
+++ b/saskatoon/sitebase/templates/app/detail_views/organization/contact.html
@@ -42,7 +42,7 @@
       {% endif %}
 
       {% if contact_person.email %}
-      <tr>
+      <tr style="word-break: break-word;">
         <td>{% trans "Email" %}</td>
         <td class="text-right">
           <h5>


### PR DESCRIPTION
Fixes #575
----------
## Type of change:
- [ ] Bug fix

----------
## What's Changed:
- used inline styling to add word-break: break-word on contact email
--------
## Screenshots:
1. large screens
<img width="597" height="374" alt="Screenshot 2026-09-10 at 10 58 04 AM" src="https://github.com/user-attachments/assets/c4e2efca-247a-4f2d-a650-a84e4331663b" />

2. mobile view
<img width="350" height="668" alt="Screenshot 2026-09-10 at 10 58 42 AM" src="https://github.com/user-attachments/assets/19cae120-a92a-4795-939b-0af8c487cdfe" />

--------
## Affected URLs:
127.0.0.1:8000/organization/<int>/