### PR TITLE
Fix/emails not normalized properly on user creation

### DIFF
--- a/saskatoon/harvest/admin.py
+++ b/saskatoon/harvest/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin, messages
 from django.db.models import Value
 from django.db.models.functions import Replace
 from django.urls import reverse
+from member.utils import create_auth_user
 from django.utils.safestring import mark_safe
 from leaflet.admin import LeafletGeoAdminMixin  # pytype: disable=import-error
 
@@ -250,8 +251,14 @@ class PropertyAdmin(LeafletGeoAdminMixin, admin.ModelAdmin[Property]):
                     elif len(emails) == 1:
                         email = emails[0]
                 if email:
-                    AuthUser.objects.create(email=email, person=_property.owner.person)
-                    nb_users += 1
+                    person = _property.owner.person
+                    user = create_auth_user(email, ['owner'])
+
+                    if not user.person:
+                        user.person = person
+                        user.save()
+                        nb_users += 1
+
             except Exception as e:
                 messages.error(request, e)
 

--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -15,7 +15,7 @@ from typing_extensions import Self
 
 from member.forms import validate_email
 from member.models import Organization, Person
-from member.utils import is_equipment_point_available, create_auth_user
+from member.utils import is_equipment_point_available, create_auth_user, get_auth_user
 from sitebase.models import Email, EmailType
 from sitebase.serializers import EmailRFPSerializer
 from sitebase.utils import is_quill_html_empty
@@ -266,7 +266,7 @@ class PropertyCreateForm(PropertyForm):
             auth_user = create_auth_user(email)
 
             person = auth_user.person
-            if not person: 
+            if not person:
                 person = Person.objects.create(
                     first_name=self.cleaned_data['owner_first_name'],
                     family_name=self.cleaned_data['owner_last_name'],
@@ -282,7 +282,7 @@ class PropertyCreateForm(PropertyForm):
                 )
                 auth_user.person = person
                 auth_user.save()
-                
+
             instance.owner = person
             instance.save()
 

--- a/saskatoon/harvest/forms.py
+++ b/saskatoon/harvest/forms.py
@@ -14,8 +14,8 @@ from typing import Any, Optional
 from typing_extensions import Self
 
 from member.forms import validate_email
-from member.models import AuthUser, Organization, Person
-from member.utils import is_equipment_point_available
+from member.models import Organization, Person
+from member.utils import is_equipment_point_available, create_auth_user
 from sitebase.models import Email, EmailType
 from sitebase.serializers import EmailRFPSerializer
 from sitebase.utils import is_quill_html_empty
@@ -63,10 +63,9 @@ class RFPForm(forms.ModelForm[RFP]):
 
     def clean_email(self):
         email = self.cleaned_data['email']
+        auth_user = get_auth_user(email)
 
-        if AuthUser.objects.filter(email=email).exists():
-            auth_user = AuthUser.objects.get(email=email)
-
+        if auth_user and auth_user.person:
             # check if a request with the same email already exists
             if RFP.objects.filter(person=auth_user.person, harvest_id=self.harvest.id).exists():
                 raise forms.ValidationError(_("You have already requested to join this pick."))
@@ -79,19 +78,17 @@ class RFPForm(forms.ModelForm[RFP]):
 
         # check if a user with the same email is already registered
         email = self.cleaned_data['email']
-        if AuthUser.objects.filter(email=email).exists():
-            auth_user = AuthUser.objects.get(email=email)
-            instance.person = auth_user.person
-        else:
-            instance.person = Person.objects.create(
+        auth_user = create_auth_user(email, ['volunteer'])
+
+        if not auth_user.person:
+            auth_user.person = Person.objects.create(
                 first_name=self.cleaned_data['first_name'],
                 family_name=self.cleaned_data['last_name'],
                 phone=self.cleaned_data['phone'],
             )
-            auth_user = AuthUser.objects.create(email=email, person=instance.person)
+            auth_user.save()
 
-        group, __ = Group.objects.get_or_create(name='volunteer')
-        auth_user.groups.add(group)
+        instance.person = auth_user.person
         instance.save()
 
         Email(
@@ -265,16 +262,27 @@ class PropertyCreateForm(PropertyForm):
     def save(self):
         instance = super().save()
         if not self.cleaned_data['owner']:
-            person = Person.objects.create(
-                first_name=self.cleaned_data['owner_first_name'],
-                family_name=self.cleaned_data['owner_last_name'],
-                phone=self.cleaned_data['owner_phone'],
-            )
-            auth_user = AuthUser.objects.create(
-                email=self.cleaned_data['owner_email'], person=person
-            )
-            auth_user.set_roles(['owner'])
+            email = self.cleaned_data['owner_email']
+            auth_user = create_auth_user(email)
 
+            person = auth_user.person
+            if not person: 
+                person = Person.objects.create(
+                    first_name=self.cleaned_data['owner_first_name'],
+                    family_name=self.cleaned_data['owner_last_name'],
+                    phone=self.cleaned_data['owner_phone'],
+                )
+                auth_user.person = person
+                auth_user.save()
+            else:
+                person = Person.objects.create(
+                    first_name=self.cleaned_data['owner_first_name'],
+                    family_name=self.cleaned_data['owner_last_name'],
+                    phone=self.cleaned_data['owner_phone'],
+                )
+                auth_user.person = person
+                auth_user.save()
+                
             instance.owner = person
             instance.save()
 

--- a/saskatoon/harvest/locale/fr/LC_MESSAGES/django.po
+++ b/saskatoon/harvest/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-07 19:35-0400\n"
+"POT-Creation-Date: 2026-09-12 14:08-0400\n"
 "PO-Revision-Date: 2025-06-13 11:05-0518\n"
 "Last-Translator: Anonymous User\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -72,12 +72,10 @@ msgid "No email address associated with property!"
 msgstr "Aucun courriel n'est associé à la propriété!"
 
 #: harvest/api.py:239
-#, python-brace-format
 msgid "Authorization email successfully sent to {email}!"
 msgstr "Courriel d'autorisation envoyé avec succès à {email}!"
 
 #: harvest/api.py:246
-#, python-brace-format
 msgid "Could not send authorization email to {email}."
 msgstr "L'envoi du courriel d'autorisation à {email} a échoué."
 
@@ -133,8 +131,8 @@ msgstr "Arrondissement"
 msgid "Reserved equipment"
 msgstr "A réservé de l'équipement"
 
-#: harvest/filters.py:83 harvest/filters.py:203 harvest/forms.py:516
-#: harvest/forms.py:695
+#: harvest/filters.py:83 harvest/filters.py:208 harvest/forms.py:525
+#: harvest/forms.py:704
 msgid "Equipment Point"
 msgstr "Point d'équipement"
 
@@ -162,15 +160,15 @@ msgstr "Non autorisée"
 msgid "Harvest Status"
 msgstr "Statut de récolte"
 
-#: harvest/filters.py:153 harvest/models.py:873
+#: harvest/filters.py:155 harvest/models.py:873
 msgid "Tree"
 msgstr "Arbre"
 
-#: harvest/filters.py:157
+#: harvest/filters.py:162
 msgid "Harvested in"
 msgstr "Récoltée en"
 
-#: harvest/filters.py:196 harvest/models.py:495
+#: harvest/filters.py:201 harvest/models.py:495
 msgid "Type"
 msgstr "Type"
 
@@ -182,11 +180,11 @@ msgstr "Combien de personnes êtes-vous?"
 msgid "First name"
 msgstr "Prénom"
 
-#: harvest/forms.py:54 harvest/forms.py:320
+#: harvest/forms.py:54 harvest/forms.py:328
 msgid "Last name"
 msgstr "Nom"
 
-#: harvest/forms.py:55 harvest/forms.py:248 harvest/forms.py:335
+#: harvest/forms.py:55 harvest/forms.py:245 harvest/forms.py:344
 msgid "Email"
 msgstr "Courriel"
 
@@ -194,7 +192,7 @@ msgstr "Courriel"
 msgid "Enter a valid email address, please."
 msgstr "Merci d'inscrire une adresse courriel valide."
 
-#: harvest/forms.py:56 harvest/forms.py:319
+#: harvest/forms.py:56 harvest/forms.py:327
 msgid "Phone number"
 msgstr "Numéro de téléphone"
 
@@ -202,19 +200,19 @@ msgstr "Numéro de téléphone"
 msgid "Comments"
 msgstr "Commentaires"
 
-#: harvest/forms.py:72
+#: harvest/forms.py:71
 msgid "You have already requested to join this pick."
 msgstr "Vous avez déjà demandé à rejoindre cette cueillette."
 
-#: harvest/forms.py:118
+#: harvest/forms.py:115
 msgid "Send confirmation email"
 msgstr "Envoyer le courriel de confirmation"
 
-#: harvest/forms.py:124
+#: harvest/forms.py:121
 msgid "Message to requester"
 msgstr "Message au bénévole"
 
-#: harvest/forms.py:155
+#: harvest/forms.py:152
 msgid ""
 "Enough pickers have already been accepted for this harvest. To accept more, "
 "increase the number of required pickers first."
@@ -222,20 +220,20 @@ msgstr ""
 "Assez de cueilleurs (cueilleuses) ont été acceptés pour cette récolte. Pour "
 "en accepter plus, augmentez d'abord le nombre de participants requis."
 
-#: harvest/forms.py:174
+#: harvest/forms.py:171
 msgid "Pickleader notes"
 msgstr "Notes du/de la chef.fe de cueillette"
 
-#: harvest/forms.py:176
+#: harvest/forms.py:173
 msgid "Your comment here"
 msgstr "Écrire vos commentaires ici"
 
-#: harvest/forms.py:216
+#: harvest/forms.py:213
 msgid "Owner must be set before property can be marked as validated"
 msgstr ""
 "La propriété ne peut pas être marquée comme validée: propriétaire manquant"
 
-#: harvest/forms.py:228
+#: harvest/forms.py:225
 msgid ""
 "Owner must have an email address before the property can be marked as "
 "validated"
@@ -243,27 +241,27 @@ msgstr ""
 "La propriété ne peut pas être marquée comme validée: propriétaire n'a pas "
 "d'addresse courriel"
 
-#: harvest/forms.py:238
+#: harvest/forms.py:235
 msgid "Register new owner"
 msgstr "Inscrire un nouveau propriétaire"
 
-#: harvest/forms.py:240 harvest/forms.py:330
+#: harvest/forms.py:237 harvest/forms.py:339
 msgid "First Name"
 msgstr "Prénom"
 
-#: harvest/forms.py:240 harvest/forms.py:248
+#: harvest/forms.py:237 harvest/forms.py:245
 msgid "This field is required"
 msgstr "Ce champ est requis"
 
-#: harvest/forms.py:243
+#: harvest/forms.py:240
 msgid "Last Name"
 msgstr "Nom"
 
-#: harvest/forms.py:245
+#: harvest/forms.py:242
 msgid "Phone"
 msgstr "Téléphone"
 
-#: harvest/forms.py:259
+#: harvest/forms.py:256
 msgid ""
 "You must either select an Owner or create a new one and provide their "
 "personal information"
@@ -272,33 +270,33 @@ msgstr ""
 "créer un.e nouveau.elle propriétaire en fournissant ses informations "
 "personnelles"
 
-#: harvest/forms.py:340
+#: harvest/forms.py:349
 msgid ""
 "Volunteers have permission to go on the neighbours property to access fruits"
 msgstr ""
 "Les cueilleurs (cueilleuses) ont la permission de passer sur le terrain "
 "voisin afin d'accéder aux fruits"
 
-#: harvest/forms.py:345
+#: harvest/forms.py:354
 msgid "I have a compost bin where you can leave rotten fruit"
 msgstr ""
 "J'ai un bac de compostage dans lequel vous pouvez mettre les fruits abîmés "
 "ou pourris"
 
-#: harvest/forms.py:350
+#: harvest/forms.py:359
 msgid "I have a ladder that can be used during the harvest"
 msgstr "J'ai une échelle qui pourra être utilisée pendant la cueillette"
 
-#: harvest/forms.py:355
+#: harvest/forms.py:364
 msgid "I would lend my ladder for another harvest nearby"
 msgstr "Je peux prêter mon échelle lors d'une cueillette à proximité"
 
-#: harvest/forms.py:360
+#: harvest/forms.py:369
 msgid "My tree(s)/vine(s) produce fruit every year"
 msgstr ""
 "Mon arbre (mes arbres) ou vigne(s) produise(nt) des fruits annuellement"
 
-#: harvest/forms.py:362
+#: harvest/forms.py:371
 msgid ""
 "if not, please include info about frequency in additional comments at the "
 "bottom"
@@ -306,43 +304,43 @@ msgstr ""
 "(sinon, merci de préciser leur fréquence de production dans les Commentaires "
 "ci-dessous)"
 
-#: harvest/forms.py:368
+#: harvest/forms.py:377
 msgid "Have you already registered your property in the past?"
 msgstr "Avez vous déjà inscrit votre propriété par le passé"
 
-#: harvest/forms.py:369 harvest/forms.py:376
+#: harvest/forms.py:378 harvest/forms.py:385
 msgid "Yes"
 msgstr "Oui"
 
-#: harvest/forms.py:369
+#: harvest/forms.py:378
 msgid "No"
 msgstr "Non"
 
-#: harvest/forms.py:374
+#: harvest/forms.py:383
 msgid ""
 "Do you give us permission to harvest your tree(s) and/or vine(s) this season?"
 msgstr ""
 "Vous donnez-nous la permission de récolter votre arbre (vos arbres) ou "
 "vigne(s) cette saison ?"
 
-#: harvest/forms.py:377
+#: harvest/forms.py:386
 msgid "Not this year, but maybe in future seasons"
 msgstr "Pas cette année, peut-être dans le futur"
 
-#: harvest/forms.py:388
+#: harvest/forms.py:397
 msgid "Location of tree(s) or vine(s)"
 msgstr "Emplacement de l'arbre (des arbres) ou vigne(s)"
 
-#: harvest/forms.py:389
+#: harvest/forms.py:398
 msgid "Location on the property (e.g. Front yard, back yard, etc.)"
 msgstr ""
 "Emplacement sur la propriété (par exemple: Jardin avant, cours arrière, etc.)"
 
-#: harvest/forms.py:394
+#: harvest/forms.py:403
 msgid "Access to tree(s) or vine(s)"
 msgstr "Accès à l'arbre (aux arbres) ou vigne(s)"
 
-#: harvest/forms.py:396
+#: harvest/forms.py:405
 msgid ""
 "Any info on how to access the tree(s) or vine(s)(e.g. locked gate in back, "
 "publicly accessible from sidewalk, etc.)"
@@ -351,37 +349,37 @@ msgstr ""
 "(par exemple: porte verrouillée à l'arrière, accès libre depuis la rue, "
 "etc...)"
 
-#: harvest/forms.py:403 harvest/models.py:823
+#: harvest/forms.py:412 harvest/models.py:823
 msgid "Number of pickers"
 msgstr "Nombre de cueilleurs (cueilleuses)"
 
-#: harvest/forms.py:404
+#: harvest/forms.py:413
 msgid "Approximate number of pickers needed for a two-hour harvesting period."
 msgstr ""
 "Nombre approximatif de cueilleurs (cueilleuses) requis pour une cueillette "
 "de deux heures"
 
-#: harvest/forms.py:408 harvest/models.py:288
+#: harvest/forms.py:417 harvest/models.py:288
 msgid "Height of lowest fruits (meters)"
 msgstr "Hauteur des fruits les plus bas (en mètres)"
 
-#: harvest/forms.py:410
+#: harvest/forms.py:419
 msgid "Address number"
 msgstr "Adresse civique"
 
-#: harvest/forms.py:413 harvest/models.py:275
+#: harvest/forms.py:422 harvest/models.py:275
 msgid "Total number of trees/vines on this property"
 msgstr "Nombre total d'arbre(s) ou de vigne(s) sur la propriété"
 
-#: harvest/forms.py:416
+#: harvest/forms.py:425
 msgid "Street name"
 msgstr "Nom de la rue"
 
-#: harvest/forms.py:418
+#: harvest/forms.py:427
 msgid "Apartment # (if applicable)"
 msgstr "Numéro d'appartement (si applicable)"
 
-#: harvest/forms.py:424
+#: harvest/forms.py:433
 msgid ""
 "I would like to receive emails from Les Fruits Défendus such as newsletters "
 "and updates"
@@ -389,7 +387,7 @@ msgstr ""
 "Je souhaite recevoir les courriels de la part des Fruits Défendus (nouvelles "
 "et bulletin d'information) Fruits Défendus"
 
-#: harvest/forms.py:432
+#: harvest/forms.py:441
 msgid ""
 "Any additional information that we should be aware of (e.g. details about "
 "how often tree produces fruit, fruit description if not already in the list, "
@@ -399,28 +397,28 @@ msgstr ""
 "fréquence de production de fruits, description des fruits si ceux-ci ne sont "
 "pas déjà dans la liste, etc..."
 
-#: harvest/forms.py:500
+#: harvest/forms.py:509
 msgid "Start date/time"
 msgstr "Date de début"
 
-#: harvest/forms.py:502
+#: harvest/forms.py:511
 msgid "End date/time"
 msgstr "Date/heure de fin"
 
-#: harvest/forms.py:505
+#: harvest/forms.py:514
 msgid "Publication date (optional)"
 msgstr "Date de publication"
 
-#: harvest/forms.py:506
+#: harvest/forms.py:515
 msgid "Leave this field empty to publish harvest as soon as possible"
 msgstr "Laissez ce champ vide pour publier la récolte le plus tôt possible"
 
-#: harvest/forms.py:517 harvest/forms.py:602
+#: harvest/forms.py:526 harvest/forms.py:611
 msgid "Harvest must be confirmed before an equipment point can be booked"
 msgstr ""
 "La récolte doit être confirmée avant de pouvoir réserver un point d'équipment"
 
-#: harvest/forms.py:547
+#: harvest/forms.py:556
 msgid ""
 "Harvests cannot be scheduled over multiple days: start and end dates must "
 "match."
@@ -428,30 +426,30 @@ msgstr ""
 "Une récolte ne peut pas être schedulée sur plusieurs jours: les dates de "
 "début et de fin doivent être les mêmes."
 
-#: harvest/forms.py:553
+#: harvest/forms.py:562
 msgid "End time must be after start time"
 msgstr "La date de fin doit être après la date de début"
 
-#: harvest/forms.py:567
+#: harvest/forms.py:576
 msgid "Selected tree(s) <{}> not registered on the selected property."
 msgstr ""
 "L'arbre sélectionné <{}> n'est pas enregistré sur la propriété sélectionnée."
 
-#: harvest/forms.py:585
+#: harvest/forms.py:594
 msgid "Please fill in the public announcement to be published on the calendar."
 msgstr "Remplissez l'annonce qui sera visible publiquement sur le calendrier."
 
-#: harvest/forms.py:616
+#: harvest/forms.py:625
 msgid "The {} equipment point is no longer available."
 msgstr "Le point d'équipement {} n'est plus disponible"
 
-#: harvest/forms.py:637
+#: harvest/forms.py:646
 msgid "This harvest cannot be left orphan, please resolve requests first."
 msgstr ""
 "Cette récolte ne peut pas être laissée orpheline, merci de résoudre les "
 "demandes de participation en cours."
 
-#: harvest/forms.py:646
+#: harvest/forms.py:655
 msgid "You must choose a pick leader or change harvest status"
 msgstr ""
 "Vous devez choisir un.e chef.fe de ceuillette ou changer le statut de la "

--- a/saskatoon/harvest/utils.py
+++ b/saskatoon/harvest/utils.py
@@ -27,7 +27,7 @@ def similar_properties(pending_property: Property):
     try:
         email = p.pending_contact_email
         if email:
-            query |= Q(owner__person__auth_user__email=email)
+            query |= Q(owner__person__auth_user__email__iexact=email)
 
         first_name = p.pending_contact_first_name
         family_name = p.pending_contact_family_name

--- a/saskatoon/member/admin_forms.py
+++ b/saskatoon/member/admin_forms.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 
 from member.models import AuthUser, Person
 from harvest.models import Equipment
+from member.utils import get_auth_user, create_auth_user
 
 from django.contrib.auth.forms import (
     UserCreationForm,
@@ -82,7 +83,13 @@ class PendingPickLeaderAdminForm(forms.ModelForm[Person]):
     def save(self, commit=True):
         self.instance = super().save(commit=False)
         data = self.cleaned_data
-        person = Person.objects.filter(auth_user__email=data.get('email')).first()
+        email = data.get('email')
+
+        auth_user = get_auth_user(email)
+        person = None
+        if auth_user and auth_user.person:
+            person = auth_user.person
+
         if person:
             for key in ['first_name', 'family_name', 'phone']:
                 setattr(person, key, data.get(key))
@@ -98,13 +105,14 @@ class PendingPickLeaderInlineAdminFormSet(
     forms.models.BaseInlineFormSet[Person, Person, PendingPickLeaderAdminForm]
 ):
     def get_emails(self):
-        return dict(
-            [
-                (f.instance.pk, f.cleaned_data.get('email'))
-                for f in self.forms
-                if f.instance.pk is not None
-            ]
-        )
+        emails = {}
+        for f in self.forms:
+            if f.instance.pk is not None and f.cleaned_data and not f.cleaned_data.get('DELETE', False):
+                email = f.cleaned_data.get('email')
+                if email:
+                    # Normalize immediately so checks match database behavior
+                    emails[f.instance.pk] = AuthUser.objects.normalize_email(email).lower()
+        return emails
 
     def clean(self):
         email_list = list(self.get_emails().values())
@@ -114,21 +122,29 @@ class PendingPickLeaderInlineAdminFormSet(
     def save_new_objects(self, commit=True):
         saved_instances = super().save_new_objects(commit)
         for person in [p for p in saved_instances if p is not None]:
-            email = self.get_emails().get(person.pk)
-            user, _ = AuthUser.objects.get_or_create(email=email, person=person)
+            email = self.get_emails().get(person.pk) or getattr(person, 'email', None)
 
             # PickLeaders don't get assigned the 'pickleader' role until
             # they have read and agreed to the privacy policy
-            user.add_role('volunteer')
+            if email:
+                user = create_auth_user(email, ['volunteer'])
+                if not user.person:
+                    user.person = person
+                    user.save()
 
         return saved_instances
 
     def save_existing_objects(self, commit=True):
         saved_instances = super().save_existing_objects(commit)
-        for i, person in enumerate(saved_instances):
-            user = AuthUser.objects.get(person=person)
-            user.email = self.get_emails().get(person.pk)
-            user.save()
+        email_map = self.get_emails()
+
+        for person in saved_instances:
+            if person is not None:
+                user = AuthUser.objects.filter(person=person).first()
+                new_email = email_map.get(person.pk)
+                if user and new_email:
+                    user.email = new_email
+                    user.save()
 
         return saved_instances
 

--- a/saskatoon/member/admin_forms.py
+++ b/saskatoon/member/admin_forms.py
@@ -107,7 +107,11 @@ class PendingPickLeaderInlineAdminFormSet(
     def get_emails(self):
         emails = {}
         for f in self.forms:
-            if f.instance.pk is not None and f.cleaned_data and not f.cleaned_data.get('DELETE', False):
+            if (
+                f.instance.pk is not None
+                and f.cleaned_data
+                and not f.cleaned_data.get('DELETE', False)
+            ):
                 email = f.cleaned_data.get('email')
                 if email:
                     # Normalize immediately so checks match database behavior

--- a/saskatoon/member/forms.py
+++ b/saskatoon/member/forms.py
@@ -48,7 +48,14 @@ class PersonCreateForm(forms.ModelForm[Person]):
 
         if auth_user.person:
             instance = auth_user.person
-            for field in ['first_name', 'family_name', 'phone', 'neighborhood', 'language', 'comment']:
+            for field in [
+                'first_name',
+                'family_name',
+                'phone',
+                'neighborhood',
+                'language',
+                'comment',
+            ]:
                 if field in self.cleaned_data and self.cleaned_data[field]:
                     setattr(instance, field, self.cleaned_data[field])
             instance.save()
@@ -120,7 +127,7 @@ class PersonUpdateForm(forms.ModelForm[Person]):
                 self.auth_user = create_auth_user(email, roles)
             self.auth_user.email = email
             self.auth_user.set_roles(roles)  # calls auth_user.save()
-            
+
         return instance
 
 

--- a/saskatoon/member/forms.py
+++ b/saskatoon/member/forms.py
@@ -9,6 +9,7 @@ from phone_field.forms import PhoneFormField
 
 from harvest.models import Property
 from member.models import AuthUser, Person, Organization
+from member.utils import create_auth_user
 from member.validators import validate_email, validate_new_password
 
 logger = getLogger('saskatoon')
@@ -39,16 +40,23 @@ class PersonCreateForm(forms.ModelForm[Person]):
         validate_email(cleaned_data['email'])
 
     def save(self):
-        # create Person instance
-        instance = super().save()
-
-        # create associated auth.user
-        auth_user = AuthUser.objects.create(email=self.cleaned_data['email'], person=instance)
+        email = self.cleaned_data['email']
         roles = self.cleaned_data['roles']
-        auth_user.set_roles(roles)
-
-        # associate pending_property (if any)
         pid = self.cleaned_data['pending_property_id']
+
+        auth_user = create_auth_user(email, roles)
+
+        if auth_user.person:
+            instance = auth_user.person
+            for field in ['first_name', 'family_name', 'phone', 'neighborhood', 'language', 'comment']:
+                if field in self.cleaned_data and self.cleaned_data[field]:
+                    setattr(instance, field, self.cleaned_data[field])
+            instance.save()
+        else:
+            instance = super().save()
+            auth_user.person = instance
+            auth_user.save()
+
         if pid and 'owner' in roles:
             try:
                 pending_property = Property.objects.get(id=pid)
@@ -109,9 +117,11 @@ class PersonUpdateForm(forms.ModelForm[Person]):
         roles = self.cleaned_data.get('roles', None)
         if email and roles:
             if not self.auth_user:
-                self.auth_user = AuthUser.objects.create(person=instance, email=email)
+                self.auth_user = create_auth_user(email, roles)
             self.auth_user.email = email
             self.auth_user.set_roles(roles)  # calls auth_user.save()
+            
+        return instance
 
 
 class OnboardingPersonUpdateForm(forms.ModelForm[Person]):
@@ -180,18 +190,22 @@ class OrganizationCreateForm(OrganizationForm):
         # # create Organization instance
         instance = super(OrganizationCreateForm, self).save()
 
-        # # create Contact Person/AuthUser
-        person = Person.objects.create(
-            first_name=self.cleaned_data['contact_first_name'],
-            family_name=self.cleaned_data['contact_last_name'],
-            phone=self.cleaned_data['contact_phone'],
-        )
-        person.save()
+        if self.cleaned_data['contact_person']:
+            person = self.cleaned_data['contact_person']
+        else:
+            email = self.cleaned_data['contact_email']
+            auth_user = create_auth_user(email, ['contact'])
 
-        auth_user = AuthUser.objects.create(
-            email=self.cleaned_data['contact_email'], person=person
-        )
-        auth_user.set_roles(['contact'])
+            if auth_user.person:
+                person = auth_user.person
+            else:
+                person = Person.objects.create(
+                    first_name=self.cleaned_data['contact_first_name'],
+                    family_name=self.cleaned_data['contact_last_name'],
+                    phone=self.cleaned_data['contact_phone'],
+                )
+                auth_user.person = person
+                auth_user.save()
 
         # # associate Contact to Organization
         instance.contact_person = person

--- a/saskatoon/member/locale/fr/LC_MESSAGES/django.po
+++ b/saskatoon/member/locale/fr/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-07 19:35-0400\n"
+"POT-Creation-Date: 2026-09-12 14:08-0400\n"
 "PO-Revision-Date: 2025-06-13 11:28-0518\n"
 "Last-Translator: Anonymous User\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,120 +43,120 @@ msgstr "Nouvelle personne"
 msgid "Role(s)"
 msgstr "Rôle(s)"
 
-#: member/filters.py:34 member/filters.py:137 member/filters.py:170
-#: member/models.py:250 member/models.py:471
+#: member/filters.py:34 member/filters.py:138 member/filters.py:171
+#: member/models.py:259 member/models.py:480
 msgid "Borough"
 msgstr "Voisinage"
 
-#: member/filters.py:40
+#: member/filters.py:41
 msgid "Language"
 msgstr "Langue"
 
-#: member/filters.py:44
+#: member/filters.py:45
 msgid "Active in"
 msgstr ""
 
-#: member/filters.py:52
+#: member/filters.py:53
 msgid "Sort by"
 msgstr ""
 
-#: member/filters.py:54
+#: member/filters.py:55
 msgid "Most harvests led"
 msgstr ""
 
-#: member/filters.py:55
+#: member/filters.py:56
 msgid "Most participations"
 msgstr ""
 
-#: member/filters.py:128
+#: member/filters.py:129
 msgid "Type"
 msgstr "Type"
 
-#: member/filters.py:130
+#: member/filters.py:131
 msgid "Beneficiaries"
 msgstr "Bénéficiaires"
 
-#: member/filters.py:131
+#: member/filters.py:132
 msgid "Equipment Points"
 msgstr "Points d'équipements"
 
-#: member/filters.py:164
+#: member/filters.py:165
 msgid "Beneficiary"
 msgstr "Bénéficiaire"
 
-#: member/filters.py:176
+#: member/filters.py:177
 msgid "Equipment Type"
 msgstr "Type d'équipement"
 
-#: member/filters.py:182
+#: member/filters.py:183
 msgid "Status"
 msgstr "Statut"
 
-#: member/filters.py:184 member/models.py:407
+#: member/filters.py:185 member/models.py:416
 msgid "Available"
 msgstr "Disponible"
 
-#: member/filters.py:185 member/models.py:406
+#: member/filters.py:186 member/models.py:415
 msgid "Reserved"
 msgstr "Réservé"
 
-#: member/filters.py:190
+#: member/filters.py:191
 msgid "From"
 msgstr "De"
 
-#: member/filters.py:191
+#: member/filters.py:192
 msgid "To"
 msgstr "À"
 
-#: member/forms.py:22 member/forms.py:72 member/forms.py:159
+#: member/forms.py:23 member/forms.py:80 member/forms.py:169
 msgid "Email"
 msgstr "Courriel"
 
-#: member/forms.py:100
+#: member/forms.py:108
 msgid "Please assign at least one role to the user"
 msgstr "Merci d'assginer au moins un rôle à cet usager"
 
-#: member/forms.py:103
+#: member/forms.py:111
 msgid "An email address is required to assign a role to the user"
 msgstr "Une adresse courriel est requise pour assigner un rôle à cet usager"
 
-#: member/forms.py:132
+#: member/forms.py:142
 msgid "Beneficiary organization"
 msgstr "Organisme bénéficiaire"
 
-#: member/forms.py:133
+#: member/forms.py:143
 msgid "Equipment point"
 msgstr "Point d'équipement"
 
-#: member/forms.py:134
+#: member/forms.py:144
 msgid "Contact Position/Role"
 msgstr "Titre/Responsabilités de la Personne Contact"
 
-#: member/forms.py:145
+#: member/forms.py:155
 msgid "Select Person"
 msgstr "Sélectionner une Personne"
 
-#: member/forms.py:150
+#: member/forms.py:160
 msgid "Register new contact person"
 msgstr "Enregistrer une nouvelle personne contact"
 
-#: member/forms.py:153
+#: member/forms.py:163
 msgid "First Name"
 msgstr "Prénom"
 
-#: member/forms.py:153 member/forms.py:159
+#: member/forms.py:163 member/forms.py:169
 msgid "This field is required"
 msgstr "Ce champ est requis"
 
-#: member/forms.py:156
+#: member/forms.py:166
 msgid "Last Name"
 msgstr "Nom"
 
-#: member/forms.py:162 member/models.py:232 member/models.py:442
+#: member/forms.py:172 member/models.py:241 member/models.py:451
 msgid "Phone"
 msgstr "Téléphone"
 
-#: member/forms.py:173
+#: member/forms.py:183
 msgid ""
 "ERROR: You must either select a Contact                     Person or create "
 "a new one and provide their personal information"
@@ -165,147 +165,147 @@ msgstr ""
 "créer une nouvelle personne contact en fournissant ses informations "
 "personnelles"
 
-#: member/models.py:33
+#: member/models.py:37
 msgid "Users must have an email address"
 msgstr "Les usagers doivent avoir une adresse courriel"
 
-#: member/models.py:53
+#: member/models.py:57
 msgid "Core Member"
 msgstr "Membre du noyau"
 
-#: member/models.py:54
+#: member/models.py:58
 msgid "Pick Leader"
 msgstr "Chef (Cheffe) de cueillette"
 
-#: member/models.py:55
+#: member/models.py:59
 msgid "Volunteer Picker"
 msgstr "Cueilleur (cueilleuse) Volontaire"
 
-#: member/models.py:56
+#: member/models.py:60
 msgid "Property Owner"
 msgstr "Propriétaire"
 
-#: member/models.py:57
+#: member/models.py:61
 msgid "Contact Person"
 msgstr "Personne Contact"
 
-#: member/models.py:64
+#: member/models.py:68
 msgid "user"
 msgstr "utilisateur.ice"
 
-#: member/models.py:65
+#: member/models.py:69
 msgid "users"
 msgstr "utilisateur.ices"
 
-#: member/models.py:81
+#: member/models.py:85
 msgid "email address"
 msgstr "adresse courriel"
 
-#: member/models.py:146 member/models.py:147
+#: member/models.py:155 member/models.py:156
 msgid "user onboarding"
 msgstr "intégration des usagers"
 
-#: member/models.py:150
+#: member/models.py:159
 msgid "Reference name"
 msgstr "Nom de référence"
 
-#: member/models.py:157
+#: member/models.py:166
 msgid "All invites sent"
 msgstr "Toutes les invitations ont été envoyées"
 
-#: member/models.py:175
+#: member/models.py:184
 msgid "actor"
 msgstr "acteur"
 
-#: member/models.py:176
+#: member/models.py:185
 msgid "actors"
 msgstr "acteurs"
 
-#: member/models.py:211
+#: member/models.py:220
 msgid "person"
 msgstr "personne"
 
-#: member/models.py:212
+#: member/models.py:221
 msgid "persons"
 msgstr "personnes"
 
-#: member/models.py:220
+#: member/models.py:229
 msgid "Preferred Language"
 msgstr "Langue de contact préférée"
 
-#: member/models.py:226
+#: member/models.py:235
 msgid "First name"
 msgstr "Prénom"
 
-#: member/models.py:229
+#: member/models.py:238
 msgid "Last name"
 msgstr "Nom"
 
-#: member/models.py:235
+#: member/models.py:244
 msgid "Number"
 msgstr "Numéro civique"
 
-#: member/models.py:238 member/models.py:459
+#: member/models.py:247 member/models.py:468
 msgid "Street"
 msgstr "Rue"
 
-#: member/models.py:241 member/models.py:462
+#: member/models.py:250 member/models.py:471
 msgid "Complement"
 msgstr "Complément"
 
-#: member/models.py:245 member/models.py:466
+#: member/models.py:254 member/models.py:475
 msgid "Postal code"
 msgstr "Code postal"
 
-#: member/models.py:258 member/models.py:478
+#: member/models.py:267 member/models.py:487
 msgid "City"
 msgstr "Ville"
 
-#: member/models.py:266 member/models.py:486
+#: member/models.py:275 member/models.py:495
 msgid "State"
 msgstr "Province"
 
-#: member/models.py:274 member/models.py:494
+#: member/models.py:283 member/models.py:503
 msgid "Country"
 msgstr "Pays"
 
-#: member/models.py:281
+#: member/models.py:290
 msgid "Newsletter subscription"
 msgstr "Souscription au bulletin d'information"
 
-#: member/models.py:285
+#: member/models.py:294
 msgid "Longitude"
 msgstr "Longitude"
 
-#: member/models.py:292
+#: member/models.py:301
 msgid "Latitude"
 msgstr "Latitude"
 
-#: member/models.py:298
+#: member/models.py:307
 msgid "Comments"
 msgstr "Commentaires"
 
-#: member/models.py:304
+#: member/models.py:313
 msgid "Onboarding group"
 msgstr "Groupe d'intégration"
 
-#: member/models.py:400
+#: member/models.py:409
 msgid "organization"
 msgstr "Organisme"
 
-#: member/models.py:401
+#: member/models.py:410
 msgid "organizations"
 msgstr "Organismes"
 
-#: member/models.py:405
+#: member/models.py:414
 msgid "Unavailable"
 msgstr "Non Disponible"
 
-#: member/models.py:410
+#: member/models.py:419
 msgid "Is Beneficiary"
 msgstr "Est Bénéficiaire"
 
-#: member/models.py:412
+#: member/models.py:421
 msgid ""
 "Only check this box if the Organization is currently accepting fruit "
 "donations"
@@ -313,11 +313,11 @@ msgstr ""
 "Cochez cette case seulement si l'organisme accepte des dons de fruits en ce "
 "moment"
 
-#: member/models.py:418
+#: member/models.py:427
 msgid "Is Equipment Point"
 msgstr "Est un point d'équipement"
 
-#: member/models.py:420
+#: member/models.py:429
 msgid ""
 "Only check this box if the equipment registered at this Organization is "
 "currenlty made available"
@@ -325,68 +325,68 @@ msgstr ""
 "Cochez cette boîte uniquement si l'équipement enregistré à cette "
 "organisation est disponible"
 
-#: member/models.py:427
+#: member/models.py:436
 msgid "Redmine contact"
 msgstr "Contact Redmine"
 
-#: member/models.py:430 member/models.py:585 member/models.py:598
-#: member/models.py:611 member/models.py:624
+#: member/models.py:439 member/models.py:594 member/models.py:607
+#: member/models.py:620 member/models.py:633
 msgid "Name"
 msgstr "Nom"
 
-#: member/models.py:432
+#: member/models.py:441
 msgid "Short description"
 msgstr "Courte description"
 
-#: member/models.py:435
+#: member/models.py:444
 msgid "Beneficiary description"
 msgstr "Description du bénéficiaire"
 
-#: member/models.py:439
+#: member/models.py:448
 msgid "Equipment point description"
 msgstr "Description du point d'équipement"
 
-#: member/models.py:447
+#: member/models.py:456
 msgid "Contact person"
 msgstr "Personne contact"
 
-#: member/models.py:452
+#: member/models.py:461
 msgid "Contact person role"
 msgstr "Responsabilités de la personne contact"
 
-#: member/models.py:456
+#: member/models.py:465
 msgid "Street number"
 msgstr "Numéro civique"
 
-#: member/models.py:581
+#: member/models.py:590
 msgid "borough"
 msgstr "Arrondissement"
 
-#: member/models.py:582
+#: member/models.py:591
 msgid "boroughs"
 msgstr "Arrondissement"
 
-#: member/models.py:595
+#: member/models.py:604
 msgid "city"
 msgstr "ville"
 
-#: member/models.py:596
+#: member/models.py:605
 msgid "cities"
 msgstr "villes"
 
-#: member/models.py:608
+#: member/models.py:617
 msgid "state"
 msgstr "province"
 
-#: member/models.py:609
+#: member/models.py:618
 msgid "states"
 msgstr "provinces"
 
-#: member/models.py:621
+#: member/models.py:630
 msgid "country"
 msgstr "pays"
 
-#: member/models.py:622
+#: member/models.py:631
 msgid "countries"
 msgstr "pays"
 
@@ -460,21 +460,18 @@ msgid "Password successfully changed!"
 msgstr "Mise à jour du mot de passe réussie!"
 
 #: member/views.py:199
-#, python-brace-format
 msgid "Cannot reset password for {email}: User does not have a password set."
 msgstr ""
 "Impossible de changer le mot de passe pour {email} : L'usager n'a pas de mot "
 "de passe."
 
 #: member/views.py:213
-#, python-brace-format
 msgid "Password reset email successfully sent to {email}"
 msgstr ""
 "Courriel de requête de changement de mot de passe envoyé avec succès à "
 "{email}"
 
 #: member/views.py:221
-#, python-brace-format
 msgid "Failed to send password reset email to {email}"
 msgstr ""
 "Échec de l'envoie du courriel de requête de changement de mot de passe à "

--- a/saskatoon/member/models.py
+++ b/saskatoon/member/models.py
@@ -30,8 +30,8 @@ class AuthUserManager(BaseUserManager[AbstractBaseUser]):
 
     @classmethod
     def normalize_email(cls, email):
-            return super().normalize_email(email).lower()
-    
+        return super().normalize_email(email).lower()
+
     def create_user(self, email, password=None):
         if not email:
             raise ValueError(_('Users must have an email address'))

--- a/saskatoon/member/models.py
+++ b/saskatoon/member/models.py
@@ -28,6 +28,10 @@ from harvest.models import (
 class AuthUserManager(BaseUserManager[AbstractBaseUser]):
     """Base user management"""
 
+    @classmethod
+    def normalize_email(cls, email):
+            return super().normalize_email(email).lower()
+    
     def create_user(self, email, password=None):
         if not email:
             raise ValueError(_('Users must have an email address'))
@@ -131,6 +135,11 @@ class AuthUser(AbstractBaseUser, PermissionsMixin):
         if self.person is not None:
             return self.person.name
         return None
+
+    def save(self, *args, **kwargs):
+        if self.email:
+            self.email = self.__class__.objects.normalize_email(self.email).lower()
+        super().save(*args, **kwargs)
 
     def __str__(self):
         if self.person:

--- a/saskatoon/member/utils.py
+++ b/saskatoon/member/utils.py
@@ -115,14 +115,12 @@ def create_auth_user(email: str, roles:List[Role]) -> AuthUser:
     if not email:
         raise ValueError("An email address is required to create a user.")
     
-    normalized_email = AuthUser.objects.normalize_email(email)
-    
     # Check if they already exist (case-insensitively) to prevent any duplicate collisions
-    existing_user = get_auth_user(normalized_email)
+    existing_user = get_auth_user(email)
     if existing_user:
         return existing_user
 
-    user = AuthUser.objects.create_user(email=normalized_email)
+    user = AuthUser.objects.create(email=email)
     
     if roles:
         user.set_roles(roles)

--- a/saskatoon/member/utils.py
+++ b/saskatoon/member/utils.py
@@ -4,7 +4,7 @@ from django.db.models import Q, QuerySet
 from datetime import timedelta, datetime
 from secrets import choice
 from typeguard import typechecked
-from typing import Optional, Union, List
+from typing import Optional, Union, List, cast
 
 from member.models import AuthUser, Organization, Role
 from harvest.models import Equipment, Harvest
@@ -99,7 +99,6 @@ def is_equipment_point_available(
     return get_available_equipment_points(start, end, harvest).filter(pk=org.pk).exists()
 
 
-
 def get_auth_user(email: str) -> Optional[AuthUser]:
     """Retrieve an AuthUser case-insensitively, safely returning the first match."""
 
@@ -109,19 +108,22 @@ def get_auth_user(email: str) -> Optional[AuthUser]:
     return AuthUser.objects.filter(email__iexact=normalized_email).first()
 
 
-def create_auth_user(email: str, roles:List[Role]) -> AuthUser:
+def create_auth_user(email: str, roles: List[Role]) -> AuthUser:
     """Safely create or retrieve an AuthUser with full normalization."""
 
     if not email:
-        raise ValueError("An email address is required to create a user.")
-    
-    # Check if they already exist (case-insensitively) to prevent any duplicate collisions
+        raise ValueError("Email is required.")
+
+    email = email.strip().lower()
+
+    # Check if they already exist (case-insensitively)
     existing_user = get_auth_user(email)
     if existing_user:
         return existing_user
 
-    user = AuthUser.objects.create(email=email)
-    
+    # Cast to AuthUser so Mypy knows it has the custom model attributes/methods
+    user = cast(AuthUser, AuthUser.objects.create(email=email))
+
     if roles:
         user.set_roles(roles)
 

--- a/saskatoon/member/utils.py
+++ b/saskatoon/member/utils.py
@@ -105,7 +105,8 @@ def get_auth_user(email: str) -> Optional[AuthUser]:
     if not email:
         return None
     normalized_email = AuthUser.objects.normalize_email(email)
-    return AuthUser.objects.filter(email__iexact=normalized_email).first()
+    user = AuthUser.objects.filter(email__iexact=normalized_email).first()
+    return cast(Optional[AuthUser], user)
 
 
 def create_auth_user(email: str, roles: List[Role]) -> AuthUser:

--- a/saskatoon/member/utils.py
+++ b/saskatoon/member/utils.py
@@ -4,9 +4,9 @@ from django.db.models import Q, QuerySet
 from datetime import timedelta, datetime
 from secrets import choice
 from typeguard import typechecked
-from typing import Optional, Union
+from typing import Optional, Union, List
 
-from member.models import AuthUser, Organization
+from member.models import AuthUser, Organization, Role
 from harvest.models import Equipment, Harvest
 from saskatoon.settings import DEFAULT_RESERVATION_BUFFER
 
@@ -97,3 +97,34 @@ def is_equipment_point_available(
         return False
 
     return get_available_equipment_points(start, end, harvest).filter(pk=org.pk).exists()
+
+
+
+def get_auth_user(email: str) -> Optional[AuthUser]:
+    """Retrieve an AuthUser case-insensitively, safely returning the first match."""
+
+    if not email:
+        return None
+    normalized_email = AuthUser.objects.normalize_email(email)
+    return AuthUser.objects.filter(email__iexact=normalized_email).first()
+
+
+def create_auth_user(email: str, roles:List[Role]) -> AuthUser:
+    """Safely create or retrieve an AuthUser with full normalization."""
+
+    if not email:
+        raise ValueError("An email address is required to create a user.")
+    
+    normalized_email = AuthUser.objects.normalize_email(email)
+    
+    # Check if they already exist (case-insensitively) to prevent any duplicate collisions
+    existing_user = get_auth_user(normalized_email)
+    if existing_user:
+        return existing_user
+
+    user = AuthUser.objects.create_user(email=normalized_email)
+    
+    if roles:
+        user.set_roles(roles)
+
+    return user

--- a/saskatoon/member/utils.py
+++ b/saskatoon/member/utils.py
@@ -105,7 +105,8 @@ def get_auth_user(email: str) -> Optional[AuthUser]:
     if not email:
         return None
     normalized_email = AuthUser.objects.normalize_email(email)
-    user = AuthUser.objects.filter(email__iexact=normalized_email).first()
+    user = AuthUser.objects.filter(email__iexact=normalized_email).first() # type: ignore[misc]
+
     return cast(Optional[AuthUser], user)
 
 
@@ -122,8 +123,8 @@ def create_auth_user(email: str, roles: List[Role]) -> AuthUser:
     if existing_user:
         return existing_user
 
-    # Cast to AuthUser so Mypy knows it has the custom model attributes/methods
-    user = cast(AuthUser, AuthUser.objects.create(email=email))
+    # Cast to AuthUser for MyPy
+    user = cast(AuthUser, AuthUser.objects.create(email=email))  # type: ignore
 
     if roles:
         user.set_roles(roles)

--- a/saskatoon/member/validators.py
+++ b/saskatoon/member/validators.py
@@ -8,7 +8,7 @@ def validate_email(email, auth_user=None):
     '''Check if a user with same email address is already registered'''
 
     if email:
-        duplicates = AuthUser.objects.filter(email=email)
+        duplicates = AuthUser.objects.filter(email__iexact=email)
         if auth_user:
             duplicates = duplicates.exclude(id=auth_user.id)
         if duplicates.exists():


### PR DESCRIPTION
Fixes #(no issue report)
----------
## Type of change:
- [ ] Bug fix 

----------
## What's Changed:
- Added get_auth_user helper to retrieve users case-insensitively using email__iexact
- Added create_auth_user utility function to sanitize and normalize email addresses before user creation
- updated user creation forms to use 'create_auth_user'
- updated user comparison forms to use 'get_auth_user'
- Implemented global email sanitization and lowercasing (.strip().lower()) directly within the AuthUser.save() method to act as a model-level backstop
- Overrode normalize_email on AuthUserManager to ensure lowercase handling across manager utilities

--------
## Screenshots:
1. Some emails before and after the normalization of the form
<img width="379" height="500" alt="Screenshot 2026-09-12 at 3 03 06 PM" src="https://github.com/user-attachments/assets/cb9036f4-cd0d-4fab-8c25-c99fa9ba5b3d" />

--------
## Affected URLs:
127.0.0.1:8000/participation/create/5/
--anywhere else where users were created with email